### PR TITLE
Burn base fees and pay tips to miners 

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kulupu"),
 	impl_name: create_runtime_str!("kulupu"),
 	authoring_version: 3,
-	spec_version: 3,
+	spec_version: 4,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -252,7 +252,7 @@ pub struct DealWithFees;
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item=NegativeImbalance>) {
 		if let Some(fees) = fees_then_tips.next() {
-			// Burn all base fees.
+			// Burn base fees.
 			drop(fees);
 			if let Some(tips) = fees_then_tips.next() {
 				// Pay tips to miners.


### PR DESCRIPTION
This changes transaction fee payment strategy similar to how it is handled in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) ([Discussions](https://github.com/ethereum/EIPs/issues/1559)). Instead of paying based fees plus tips to miners, we burn base fee, and pay only tips to miners.

The rationale section of EIP-1559 has a good description of why we may also want to do this:

> An important aspect of this upgraded fee system is that miners only get to keep the tips. The base fee is always burned (i.e. it is destroyed by the protocol). Burning this is important because it prevents miners from manipulating the fee in order to extract more fees from users. It also ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform. Additionally, this burn counterbalances Ethereum inflation without greatly diminishing miner rewards.