### PR TITLE
Azure Pipeline (Windows) Clean Up

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,6 @@ jobs:
       rustup update nightly
       rustup update stable
       rustup target add wasm32-unknown-unknown --toolchain nightly
-      cargo +nightly install --git https://github.com/alexcrichton/wasm-gc --force
     displayName: 'Rust setup'
   - script: |
       set LIBCLANG_PATH=d:\c\llvm+clang+lld-10.0.0-x86_64-windows-msvc-release-mt\bin

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,17 +63,12 @@ jobs:
   - script: git submodule update --init --recursive
     displayName: 'Submodules'
   - script: |
-      curl -f -o d:\llvm+clang+lld-10.0.0-x86_64-windows-msvc-release-mt.tar.xz https://ziglang.org/deps/llvm+clang+lld-10.0.0-x86_64-windows-msvc-release-mt.tar.xz
-      7z x "d:\llvm+clang+lld-10.0.0-x86_64-windows-msvc-release-mt.tar.xz" -so | 7z x -aoa -si -ttar -o"d:\c"
-      dir d:\c\llvm+clang+lld-10.0.0-x86_64-windows-msvc-release-mt\bin
-    displayName: 'Libclang setup'
-  - script: |
       rustup update nightly
       rustup update stable
       rustup target add wasm32-unknown-unknown --toolchain nightly
     displayName: 'Rust setup'
   - script: |
-      set LIBCLANG_PATH=d:\c\llvm+clang+lld-10.0.0-x86_64-windows-msvc-release-mt\bin
+      set LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin
       cargo build --release
     displayName: 'Build artifacts'
   - task: ArchiveFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
 
 - job: Windows
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2019'
   timeoutInMinutes: 0
   steps:
   - script: git submodule update --init --recursive


### PR DESCRIPTION
This is minor, but it removes the requirement of downloading LLVM/Clang as well as the usage of wasm-gc. Additionally, since we are using a specific VS location for LLVM, I changed the vmImage to `windows-2019` to reduce the potential of broken requirements.