### PR TITLE
Increase token decimals from 12 to 13

### DIFF
--- a/res/eras/1/3-swamp-bottom/config.json
+++ b/res/eras/1/3-swamp-bottom/config.json
@@ -9,7 +9,7 @@
   "protocolId": "kulupu",
   "properties": {
     "ss58Format": 16,
-    "tokenDecimals": 12,
+    "tokenDecimals": 13,
     "tokenSymbol": "KLP"
   },
   "consensusEngine": null,


### PR DESCRIPTION
Note that this is not yet suitable for merge. Although this is a simple display change, we need to have an on-chain adversary vote to enact this, following the tradition of Polkadot/Kusama.