### PR TITLE
Allow setting block rewards by democracy voting

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -308,6 +308,7 @@ parameter_types! {
 }
 
 impl rewards::Trait for Runtime {
+	type Event = Event;
 	type Reward = Reward;
 }
 
@@ -627,7 +628,7 @@ construct_runtime!(
 		// PoW consensus and era support.
 		Difficulty: difficulty::{Module, Call, Storage, Config},
 		Eras: eras::{Module, Call, Storage, Config<T>},
-		Rewards: rewards::{Module, Call, Inherent, Storage},
+		Rewards: rewards::{Module, Call, Inherent, Storage, Event<T>},
 
 		// Governance.
 		Democracy: democracy::{Module, Call, Storage, Config, Event<T>},


### PR DESCRIPTION
Add function `set_reward` that can be called by democracy voting.