### PR TITLE
Voluntary taxation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,6 +3594,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-treasury",
  "parity-scale-codec",
  "serde",
  "sp-inherents",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,7 +3594,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
- "pallet-treasury",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/frame/rewards/Cargo.toml
+++ b/frame/rewards/Cargo.toml
@@ -12,12 +12,11 @@ sp-std = { path = "../../vendor/substrate/primitives/std", default-features = fa
 sp-inherents = { path = "../../vendor/substrate/primitives/inherents", default-features = false }
 frame-support = { path = "../../vendor/substrate/frame/support", default-features = false }
 frame-system = { path = "../../vendor/substrate/frame/system", default-features = false }
-pallet-balances = { path = "../../vendor/substrate/frame/balances", default-features = false }
-pallet-treasury = { path = "../../vendor/substrate/frame/treasury", default-features = false }
 
 [dev-dependencies]
 sp-core = { path = "../../vendor/substrate/primitives/core", default-features = false }
 sp-io = { path = "../../vendor/substrate/primitives/io", default-features = false }
+pallet-balances = { path = "../../vendor/substrate/frame/balances", default-features = false }
 
 [features]
 default = ["std"]
@@ -29,6 +28,4 @@ std = [
 	"sp-inherents/std",
 	"frame-support/std",
 	"frame-system/std",
-	"pallet-balances/std",
-	"pallet-treasury/std",
 ]

--- a/frame/rewards/Cargo.toml
+++ b/frame/rewards/Cargo.toml
@@ -13,6 +13,7 @@ sp-inherents = { path = "../../vendor/substrate/primitives/inherents", default-f
 frame-support = { path = "../../vendor/substrate/frame/support", default-features = false }
 frame-system = { path = "../../vendor/substrate/frame/system", default-features = false }
 pallet-balances = { path = "../../vendor/substrate/frame/balances", default-features = false }
+pallet-treasury = { path = "../../vendor/substrate/frame/treasury", default-features = false }
 
 [features]
 default = ["std"]
@@ -25,4 +26,5 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
+	"pallet-treasury/std",
 ]

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -32,7 +32,7 @@ use sp_inherents::ProvideInherentData;
 use frame_support::{
 	decl_module, decl_storage, decl_error, decl_event, ensure,
 	traits::{Get, Currency},
-	weights::DispatchClass,
+	weights::{DispatchClass, Weight},
 };
 use frame_system::{ensure_none, ensure_root};
 
@@ -145,6 +145,13 @@ decl_module! {
 
 			<Self as Store>::Author::kill();
 			<Self as Store>::AuthorDonation::kill();
+		}
+
+		// [fixme: should be removed in next runtime upgrade]
+		fn on_runtime_upgrade() -> Weight {
+			Taxation::put(Permill::zero());
+
+			0
 		}
 	}
 }

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -69,7 +69,7 @@ decl_storage! {
 		/// Current block reward.
 		Reward get(fn reward) config(): BalanceOf<T>;
 		/// Taxation rate.
-		Taxation get(fn taxation): Permill;
+		Taxation get(fn taxation) config(): Permill;
 	}
 }
 

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -20,7 +20,7 @@ use crate::{Module, Trait, GenesisConfig};
 use sp_core::H256;
 use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
 use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill, Permill,
+	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill,
 };
 use frame_system as system;
 
@@ -112,7 +112,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	GenesisConfig::<Test> {
 		reward: 60,
-		taxation: Permill::from_percent(10),
+		taxation: Perbill::from_percent(10),
 	}.assimilate_storage(&mut t).unwrap();
 
 	let mut ext = sp_io::TestExternalities::new(t);

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -20,7 +20,7 @@ use crate::{Module, Trait, GenesisConfig};
 use sp_core::H256;
 use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
 use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill,
+	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill, Permill,
 };
 use frame_system as system;
 
@@ -93,9 +93,14 @@ impl pallet_balances::Trait for Test {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub DonationDestination: u64 = 255;
+}
+
 impl Trait for Test {
 	type Event = Event;
 	type Currency = Balances;
+	type DonationDestination = DonationDestination;
 }
 
 pub type System = frame_system::Module<Test>;
@@ -107,6 +112,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	GenesisConfig::<Test> {
 		reward: 60,
+		taxation: Permill::from_percent(10),
 	}.assimilate_storage(&mut t).unwrap();
 
 	let mut ext = sp_io::TestExternalities::new(t);

--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -65,11 +65,11 @@ fn set_reward_works() {
 fn set_author_works() {
 	new_test_ext().execute_with(|| {
 		// Fails with bad origin
-		assert_noop!(Rewards::set_author(Origin::signed(1), 1, Permill::zero()), BadOrigin);
+		assert_noop!(Rewards::set_author(Origin::signed(1), 1, Perbill::zero()), BadOrigin);
 		// Block author can successfully set themselves
-		assert_ok!(Rewards::set_author(Origin::none(), 1, Permill::zero()));
+		assert_ok!(Rewards::set_author(Origin::none(), 1, Perbill::zero()));
 		// Cannot set author twice
-		assert_noop!(Rewards::set_author(Origin::none(), 2, Permill::zero()), Error::<Test>::AuthorAlreadySet);
+		assert_noop!(Rewards::set_author(Origin::none(), 2, Perbill::zero()), Error::<Test>::AuthorAlreadySet);
 		assert_eq!(Author::<Test>::get(), Some(1));
 	});
 }
@@ -78,15 +78,16 @@ fn set_author_works() {
 fn reward_payment_works() {
 	new_test_ext().execute_with(|| {
 		// Block author sets themselves as author
-		assert_ok!(Rewards::set_author(Origin::none(), 1, Permill::zero()));
+		assert_ok!(Rewards::set_author(Origin::none(), 1, Perbill::zero()));
 		// Next block
 		next_block();
 		// User gets reward
-		assert_eq!(Balances::free_balance(1), 60);
+		assert_eq!(Balances::free_balance(1), 54);
 
 		// Set new reward
 		assert_ok!(Rewards::set_reward(Origin::root(), 42));
-		assert_ok!(Rewards::set_author(Origin::none(), 2, Permill::zero()));
+		assert_ok!(Rewards::set_taxation(Origin::root(), Perbill::zero()));
+		assert_ok!(Rewards::set_author(Origin::none(), 2, Perbill::zero()));
 		next_block();
 		assert_eq!(Balances::free_balance(2), 42);
 	});

--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -65,11 +65,11 @@ fn set_reward_works() {
 fn set_author_works() {
 	new_test_ext().execute_with(|| {
 		// Fails with bad origin
-		assert_noop!(Rewards::set_author(Origin::signed(1), 1), BadOrigin);
+		assert_noop!(Rewards::set_author(Origin::signed(1), 1, Permill::zero()), BadOrigin);
 		// Block author can successfully set themselves
-		assert_ok!(Rewards::set_author(Origin::none(), 1));
+		assert_ok!(Rewards::set_author(Origin::none(), 1, Permill::zero()));
 		// Cannot set author twice
-		assert_noop!(Rewards::set_author(Origin::none(), 2), Error::<Test>::AuthorAlreadySet);
+		assert_noop!(Rewards::set_author(Origin::none(), 2, Permill::zero()), Error::<Test>::AuthorAlreadySet);
 		assert_eq!(Author::<Test>::get(), Some(1));
 	});
 }
@@ -78,7 +78,7 @@ fn set_author_works() {
 fn reward_payment_works() {
 	new_test_ext().execute_with(|| {
 		// Block author sets themselves as author
-		assert_ok!(Rewards::set_author(Origin::none(), 1));
+		assert_ok!(Rewards::set_author(Origin::none(), 1, Permill::zero()));
 		// Next block
 		next_block();
 		// User gets reward
@@ -86,7 +86,7 @@ fn reward_payment_works() {
 
 		// Set new reward
 		assert_ok!(Rewards::set_reward(Origin::root(), 42));
-		assert_ok!(Rewards::set_author(Origin::none(), 2));
+		assert_ok!(Rewards::set_author(Origin::none(), 2, Permill::zero()));
 		next_block();
 		assert_eq!(Balances::free_balance(2), 42);
 	});

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -658,7 +658,7 @@ construct_runtime!(
 		// PoW consensus and era support.
 		Difficulty: difficulty::{Module, Call, Storage, Config},
 		Eras: eras::{Module, Call, Storage, Config<T>},
-		Rewards: rewards::{Module, Call, Inherent, Storage, Event<T>},
+		Rewards: rewards::{Module, Call, Inherent, Storage, Event<T>, Config<T>},
 
 		// Governance.
 		Democracy: democracy::{Module, Call, Storage, Config, Event<T>},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 7,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 3,
+	transaction_version: 4,
 };
 
 /// The version infromation used to identify this runtime when compiled natively.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -497,7 +497,7 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 20 * DOLLARS;
 	pub const SpendPeriod: BlockNumber = 6 * DAYS;
-	pub const Burn: Permill = Permill::from_percent(0);
+	pub const Burn: Permill = Permill::from_percent(1);
 	pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
 
 	pub const TipCountdown: BlockNumber = 1 * DAYS;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -322,7 +322,6 @@ impl difficulty::Trait for Runtime {
 impl eras::Trait for Runtime { }
 
 parameter_types! {
-	pub const Reward: Balance = 60 * DOLLARS;
 	pub DonationDestination: AccountId = Treasury::account_id();
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -323,11 +323,13 @@ impl eras::Trait for Runtime { }
 
 parameter_types! {
 	pub const Reward: Balance = 60 * DOLLARS;
+	pub DonationDestination: AccountId = Treasury::account_id();
 }
 
 impl rewards::Trait for Runtime {
 	type Event = Event;
 	type Currency = Balances;
+	type DonationDestination = DonationDestination;
 }
 
 pub struct Author;

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -16,10 +16,11 @@
 
 use serde_json::json;
 use sp_core::{U256, crypto::UncheckedFrom};
+use sp_runtime::Permill;
 use sc_service::ChainType;
 use kulupu_runtime::{
 	BalancesConfig, GenesisConfig, IndicesConfig, SystemConfig,
-	DifficultyConfig, ErasConfig, AccountId, WASM_BINARY,
+	DifficultyConfig, ErasConfig, AccountId, RewardsConfig, WASM_BINARY,
 };
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
@@ -94,6 +95,10 @@ fn testnet_genesis(initial_difficulty: U256) -> GenesisConfig {
 		membership_Instance1: Some(Default::default()),
 		timestamp: Some(Default::default()),
 		vesting: Some(Default::default()),
+		rewards: Some(RewardsConfig {
+			reward: 60_000_000_000_000,
+			taxation: Permill::from_percent(0),
+		}),
 	}
 }
 
@@ -137,5 +142,9 @@ pub fn mainnet_genesis() -> GenesisConfig {
 		membership_Instance1: Some(Default::default()),
 		timestamp: Some(Default::default()),
 		vesting: None,
+		rewards: Some(RewardsConfig {
+			reward: 60_000_000_000_000,
+			taxation: Permill::from_percent(0),
+		}),
 	}
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -18,6 +18,7 @@ use serde_json::json;
 use sp_core::{U256, crypto::UncheckedFrom};
 use sp_runtime::Permill;
 use sc_service::ChainType;
+use kulupu_primitives::DOLLARS;
 use kulupu_runtime::{
 	BalancesConfig, GenesisConfig, IndicesConfig, SystemConfig,
 	DifficultyConfig, ErasConfig, AccountId, RewardsConfig, WASM_BINARY,
@@ -96,7 +97,7 @@ fn testnet_genesis(initial_difficulty: U256) -> GenesisConfig {
 		timestamp: Some(Default::default()),
 		vesting: Some(Default::default()),
 		rewards: Some(RewardsConfig {
-			reward: 60_000_000_000_000,
+			reward: 60 * DOLLARS,
 			taxation: Permill::from_percent(0),
 		}),
 	}
@@ -143,7 +144,7 @@ pub fn mainnet_genesis() -> GenesisConfig {
 		timestamp: Some(Default::default()),
 		vesting: None,
 		rewards: Some(RewardsConfig {
-			reward: 60_000_000_000_000,
+			reward: 60 * DOLLARS,
 			taxation: Permill::from_percent(0),
 		}),
 	}

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -16,7 +16,7 @@
 
 use serde_json::json;
 use sp_core::{U256, crypto::UncheckedFrom};
-use sp_runtime::Permill;
+use sp_runtime::Perbill;
 use sc_service::ChainType;
 use kulupu_primitives::DOLLARS;
 use kulupu_runtime::{
@@ -98,7 +98,7 @@ fn testnet_genesis(initial_difficulty: U256) -> GenesisConfig {
 		vesting: Some(Default::default()),
 		rewards: Some(RewardsConfig {
 			reward: 60 * DOLLARS,
-			taxation: Permill::from_percent(0),
+			taxation: Perbill::from_percent(0),
 		}),
 	}
 }
@@ -145,7 +145,7 @@ pub fn mainnet_genesis() -> GenesisConfig {
 		vesting: None,
 		rewards: Some(RewardsConfig {
 			reward: 60 * DOLLARS,
-			taxation: Permill::from_percent(0),
+			taxation: Perbill::from_percent(0),
 		}),
 	}
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,8 @@ pub struct Cli {
 	#[structopt(long)]
 	pub enable_polkadot_telemetry: bool,
 	#[structopt(long)]
+	pub donate: bool,
+	#[structopt(long)]
 	pub check_inherents_after: Option<u32>,
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -78,7 +78,7 @@ pub fn run() -> sc_cli::Result<()> {
 		Some(Subcommand::Base(subcommand)) => {
 			let runner = cli.create_runner(subcommand)?;
 			runner.run_subcommand(subcommand, |config| {
-				let (builder, _, _) = new_full_start!(config, None, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER));
+				let (builder, _, _) = new_full_start!(config, None, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), cli.donate);
 				Ok(builder.to_chain_ops_parts())
 			})
 		},
@@ -112,6 +112,7 @@ pub fn run() -> sc_cli::Result<()> {
 						config,
 						cli.author.as_ref().map(|s| s.as_str()),
 						cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER),
+						cli.donate,
 					),
 					_ => service::new_full(
 						config,
@@ -119,6 +120,7 @@ pub fn run() -> sc_cli::Result<()> {
 						cli.threads.unwrap_or(1),
 						cli.round.unwrap_or(5000),
 						cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER),
+						cli.donate,
 					)
 				}
 			)

--- a/src/service.rs
+++ b/src/service.rs
@@ -19,6 +19,7 @@
 use std::sync::Arc;
 use std::str::FromStr;
 use codec::Encode;
+use sp_runtime::Permill;
 use sp_core::{H256, crypto::{UncheckedFrom, Ss58Codec, Ss58AddressFormat}};
 use sc_consensus::LongestChain;
 use sc_service::{
@@ -54,7 +55,7 @@ pub fn kulupu_inherent_data_providers(
 		if !inherent_data_providers.has_provider(&pallet_rewards::INHERENT_IDENTIFIER) {
 			inherent_data_providers
 				.register_provider(pallet_rewards::InherentDataProvider(
-					if author.starts_with("0x") {
+					(if author.starts_with("0x") {
 						AccountId::unchecked_from(
 							H256::from_str(&author[2..]).expect("Invalid author account")
 						)
@@ -63,7 +64,7 @@ pub fn kulupu_inherent_data_providers(
 							.expect("Invalid author address");
 						assert!(version == Ss58AddressFormat::KulupuAccount, "Invalid author version");
 						address
-					}.encode()
+					}.encode(), Permill::zero())
 				))
 				.map_err(Into::into)
 				.map_err(sp_consensus::Error::InherentData)?;

--- a/src/service.rs
+++ b/src/service.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 use std::str::FromStr;
 use codec::Encode;
-use sp_runtime::{Permill, traits::Bounded};
+use sp_runtime::{Perbill, traits::Bounded};
 use sp_core::{H256, crypto::{UncheckedFrom, Ss58Codec, Ss58AddressFormat}};
 use sc_consensus::LongestChain;
 use sc_service::{
@@ -75,7 +75,7 @@ pub fn kulupu_inherent_data_providers(
 		if !inherent_data_providers.has_provider(&pallet_rewards::INHERENT_IDENTIFIER) {
 			inherent_data_providers
 				.register_provider(pallet_rewards::InherentDataProvider(
-					(encoded_author, if donate { Permill::max_value() } else { Permill::zero() })
+					(encoded_author, if donate { Perbill::max_value() } else { Perbill::zero() })
 				))
 				.map_err(Into::into)
 				.map_err(sp_consensus::Error::InherentData)?;


### PR DESCRIPTION
This PR implements voluntary taxation. Note that voluntary taxation is still under discussion and is not necessarily accepted by Kulupu governance.

Voluntary taxation works by setting a fixed taxation rate. It's initially zero, and can be changed by democracy referendum. When set, all miners' reward will be reduced by this amount. If they do nothing else, this "tax" will simply be burned and removed from total supply. Miners can optionally (opt-in) choose to donate this "tax" to treasury, by calling the "donate" inherent extrinsic.

As an example, if the taxation is 1%, and block reward is 60 KLP, then:

* If a miner chooses not to donate, then she/he will get 59.4 KLP per block mined. The rest of 0.6 KLP is burned. No one gets that.
* The miner can optionally (opt-in) choose to run the mining software with `--donate` flag. If so, then she/he will get 59.4 KLP per block mined. The rest of 0.6 KLP will be donated to treasury.

As an addition together with this voluntary taxation model, I think it's also important we burn unused treasury fund to encourage spending and avoid treasury accumulation -- the treasury burn rate is set to 1%, meaning each spending period 1% of the total treasury will simply get burned.