### PR TITLE
Update and Add Tests to Rewards Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,7 +3596,9 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "serde",
+ "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/frame/rewards/Cargo.toml
+++ b/frame/rewards/Cargo.toml
@@ -14,6 +14,10 @@ frame-support = { path = "../../vendor/substrate/frame/support", default-feature
 frame-system = { path = "../../vendor/substrate/frame/system", default-features = false }
 pallet-balances = { path = "../../vendor/substrate/frame/balances", default-features = false }
 
+[dev-dependencies]
+sp-core = { path = "../../vendor/substrate/primitives/core", default-features = false }
+sp-io = { path = "../../vendor/substrate/primitives/io", default-features = false }
+
 [features]
 default = ["std"]
 std = [

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -51,6 +51,8 @@ decl_error! {
 	pub enum Error for Module<T: Trait> {
 		/// Author already set in block.
 		AuthorAlreadySet,
+		/// Reward set is too low.
+		RewardTooLow,
 	}
 }
 
@@ -93,6 +95,7 @@ decl_module! {
 		)]
 		fn set_reward(origin, reward: BalanceOf<T>) {
 			ensure_root(origin)?;
+			ensure!(reward >= T::Currency::minimum_balance(), Error::<T>::RewardTooLow);
 			Reward::<T>::put(reward);
 			Self::deposit_event(RawEvent::RewardChanged(reward))
 		}

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -41,7 +41,6 @@ impl_outer_event! {
 }
 
 // Configure a mock runtime to test the pallet.
-
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -1,0 +1,116 @@
+// Copyright 2019-2020 Wei Tang.
+// This file is part of Kulupu.
+
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Mock runtime for tests
+
+use crate::{Module, Trait, GenesisConfig};
+use sp_core::H256;
+use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill,
+};
+use frame_system as system;
+
+impl_outer_origin! {
+	pub enum Origin for Test {}
+}
+
+mod pallet_rewards {
+	pub use crate::Event;
+}
+
+impl_outer_event! {
+	pub enum Event for Test {
+		frame_system<T>,
+		pallet_balances<T>,
+		pallet_rewards<T>,
+	}
+}
+
+// Configure a mock runtime to test the pallet.
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct Test;
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+}
+
+type Balance = u128;
+
+impl system::Trait for Test {
+	type BaseCallFilter = ();
+	type Origin = Origin;
+	type Call = ();
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type DbWeight = ();
+	type BlockExecutionWeight = ();
+	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 1;
+}
+
+impl pallet_balances::Trait for Test {
+	type Balance = Balance;
+	type DustRemoval = ();
+	type Event = Event;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+}
+
+impl Trait for Test {
+	type Event = Event;
+	type Currency = Balances;
+}
+
+pub type System = frame_system::Module<Test>;
+pub type Balances = pallet_balances::Module<Test>;
+pub type Rewards = Module<Test>;
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	GenesisConfig::<Test> {
+		reward: 60,
+	}.assimilate_storage(&mut t).unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -1,0 +1,91 @@
+// Copyright 2019-2020 Wei Tang.
+// This file is part of Kulupu.
+
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Tests for Rewards Pallet
+
+use crate::*;
+use crate::mock::*;
+use frame_support::{assert_ok, assert_noop};
+use frame_support::error::BadOrigin;
+use frame_support::traits::{OnInitialize, OnFinalize};
+
+// Get the last event from System
+fn last_event() -> mock::Event {
+	System::events().pop().expect("Event expected").event
+}
+
+// Run until a particular block.
+fn next_block() {
+	Rewards::on_finalize(System::block_number());
+	Balances::on_finalize(System::block_number());
+	System::set_block_number(System::block_number() + 1);
+	Balances::on_initialize(System::block_number());
+	Rewards::on_initialize(System::block_number());
+}
+
+#[test]
+fn genesis_config_works() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(Author::<Test>::get(), None);
+		assert_eq!(Reward::<Test>::get(), 60);
+		assert_eq!(Balances::free_balance(1), 0);
+		assert_eq!(Balances::free_balance(2), 0);
+	});
+}
+
+#[test]
+fn set_reward_works() {
+	new_test_ext().execute_with(|| {
+		// Fails with bad origin
+		assert_noop!(Rewards::set_reward(Origin::signed(1), 42), BadOrigin);
+		assert_noop!(Rewards::set_reward(Origin::none(), 42), BadOrigin);
+		// Successful
+		assert_ok!(Rewards::set_reward(Origin::root(), 42));
+		assert_eq!(Reward::<Test>::get(), 42);
+		assert_eq!(last_event(), RawEvent::RewardChanged(42).into());
+	});
+}
+
+#[test]
+fn set_author_works() {
+	new_test_ext().execute_with(|| {
+		// Fails with bad origin
+		assert_noop!(Rewards::set_author(Origin::signed(1), 1), BadOrigin);
+		// Block author can successfully set themselves
+		assert_ok!(Rewards::set_author(Origin::none(), 1));
+		// Cannot set author twice
+		assert_noop!(Rewards::set_author(Origin::none(), 2), Error::<Test>::AuthorAlreadySet);
+		assert_eq!(Author::<Test>::get(), Some(1));
+	});
+}
+
+#[test]
+fn reward_payment_works() {
+	new_test_ext().execute_with(|| {
+		// Block author sets themselves as author
+		assert_ok!(Rewards::set_author(Origin::none(), 1));
+		// Next block
+		next_block();
+		// User gets reward
+		assert_eq!(Balances::free_balance(1), 60);
+
+		// Set new reward
+		assert_ok!(Rewards::set_reward(Origin::root(), 42));
+		assert_ok!(Rewards::set_author(Origin::none(), 2));
+		next_block();
+		assert_eq!(Balances::free_balance(2), 42);
+	});
+}

--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -56,6 +56,8 @@ fn set_reward_works() {
 		assert_ok!(Rewards::set_reward(Origin::root(), 42));
 		assert_eq!(Reward::<Test>::get(), 42);
 		assert_eq!(last_event(), RawEvent::RewardChanged(42).into());
+		// Fails when too low
+		assert_noop!(Rewards::set_reward(Origin::root(), 0), Error::<Test>::RewardTooLow);
 	});
 }
 

--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -27,7 +27,7 @@ fn last_event() -> mock::Event {
 	System::events().pop().expect("Event expected").event
 }
 
-// Run until a particular block.
+// Move to the next block.
 fn next_block() {
 	Rewards::on_finalize(System::block_number());
 	Balances::on_finalize(System::block_number());

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -327,7 +327,7 @@ parameter_types! {
 
 impl rewards::Trait for Runtime {
 	type Event = Event;
-	type Reward = Reward;
+	type Currency = Balances;
 }
 
 pub struct Author;


### PR DESCRIPTION
MERGE ONLY AFTER SEEKER CAMP UPGRADE

This PR updates the rewards pallet in the following ways:

* Removes `Reward` config (has since been deprecated to be a storage item).
* Removes `on_runtime_upgrade` and other artifacts of the migration of Reward.
* Introduces Genesis config for new Reward storage item to allow for an initial reward to be set for new chains.
* Introduces `Currency` trait in favor of depending on `pallet_balances` directly.
* Check that `set_reward` value is greater than or equal to the existential deposit.

Additionally, this PR adds basic runtime tests to verify extrinsics behave as expected, and the end to end reward process works.