### PR TITLE
Calibrate treasury and technical committee threshold

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,7 +28,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use sp_std::prelude::*;
 use codec::{Encode, Decode};
-use sp_core::{OpaqueMetadata, u32_trait::{_1, _2, _4, _5, _9, _10}};
+use sp_core::{OpaqueMetadata, u32_trait::{_1, _2, _4, _5}};
 use sp_runtime::{
 	ApplyExtrinsicResult, Percent, ModuleId, generic, create_runtime_str, MultiSignature,
 	RuntimeDebug, Perquintill, transaction_validity::{TransactionValidity, TransactionSource},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -483,13 +483,14 @@ impl collective::Trait<TechnicalCollective> for Runtime {
 	type WeightInfo = ();
 }
 
-impl membership::Trait<membership::Instance1> for Runtime {
+type TechnicalMembership = membership::Instance1;
+impl membership::Trait<TechnicalMembership> for Runtime {
 	type Event = Event;
-	type AddOrigin = collective::EnsureProportionAtLeast<_9, _10, AccountId, CouncilCollective>;
-	type RemoveOrigin = collective::EnsureProportionAtLeast<_9, _10, AccountId, CouncilCollective>;
-	type SwapOrigin = collective::EnsureProportionAtLeast<_9, _10, AccountId, CouncilCollective>;
-	type ResetOrigin = collective::EnsureProportionAtLeast<_9, _10, AccountId, CouncilCollective>;
-	type PrimeOrigin = collective::EnsureProportionAtLeast<_9, _10, AccountId, CouncilCollective>;
+	type AddOrigin = system::EnsureRoot<AccountId>;
+	type RemoveOrigin = system::EnsureRoot<AccountId>;
+	type SwapOrigin = system::EnsureRoot<AccountId>;
+	type ResetOrigin = system::EnsureRoot<AccountId>;
+	type PrimeOrigin = system::EnsureRoot<AccountId>;
 	type MembershipInitialized = TechnicalCommittee;
 	type MembershipChanged = TechnicalCommittee;
 }
@@ -509,8 +510,8 @@ parameter_types! {
 
 impl treasury::Trait for Runtime {
 	type Currency = Balances;
-	type ApproveOrigin = collective::EnsureProportionAtLeast<_4, _5, AccountId, CouncilCollective>;
-	type RejectOrigin = collective::EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>;
+	type ApproveOrigin = collective::EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>;
+	type RejectOrigin = collective::EnsureProportionMoreThan<_1, _5, AccountId, CouncilCollective>;
 	type Tippers = ElectionsPhragmen;
 	type TipCountdown = TipCountdown;
 	type TipFindersFee = TipFindersFee;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -483,8 +483,7 @@ impl collective::Trait<TechnicalCollective> for Runtime {
 	type WeightInfo = ();
 }
 
-type TechnicalMembership = membership::Instance1;
-impl membership::Trait<TechnicalMembership> for Runtime {
+impl membership::Trait<membership::Instance1> for Runtime {
 	type Event = Event;
 	type AddOrigin = system::EnsureRoot<AccountId>;
 	type RemoveOrigin = system::EnsureRoot<AccountId>;


### PR DESCRIPTION
This PR does two things:

* Change treasury approval origin from 4/5 to 1/2, and change treasury reject origin from 1/2 to 1/5. The rationale is that right now 4/5 is too difficult for a treasury proposal to pass, as we don't have enough council members participating in voting. In the mean time, to prevent abuse, make sure a small portion of the council member can reject a treasury proposal.
* Change technical committee membership so that it's membership is controlled directly by democracy referendum. This is to prevent technical committee from colliding with council -- right now the only role technical committee serves is to fast track proposals submitted by council, but technical committee is also appointed by council, which means the separation of duty is not yet working.