### PR TITLE
Tests for Reward Locks

### DIFF
--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -21,19 +21,22 @@ use crate::mock::*;
 use frame_support::{assert_ok, assert_noop};
 use frame_support::error::BadOrigin;
 use frame_support::traits::{OnInitialize, OnFinalize};
+use pallet_balances::Error as BalancesError;
 
 // Get the last event from System
 fn last_event() -> mock::Event {
 	System::events().pop().expect("Event expected").event
 }
 
-// Move to the next block.
-fn next_block() {
-	Rewards::on_finalize(System::block_number());
-	Balances::on_finalize(System::block_number());
-	System::set_block_number(System::block_number() + 1);
-	Balances::on_initialize(System::block_number());
-	Rewards::on_initialize(System::block_number());
+/// Run until a particular block.
+fn run_to_block(n: u64) {
+	while System::block_number() < n {
+		Rewards::on_finalize(System::block_number());
+		Balances::on_finalize(System::block_number());
+		System::set_block_number(System::block_number() + 1);
+		Balances::on_initialize(System::block_number());
+		Rewards::on_initialize(System::block_number());
+	}
 }
 
 #[test]
@@ -43,6 +46,7 @@ fn genesis_config_works() {
 		assert_eq!(Reward::<Test>::get(), 60);
 		assert_eq!(Balances::free_balance(1), 0);
 		assert_eq!(Balances::free_balance(2), 0);
+		assert_eq!(System::block_number(), 1);
 	});
 }
 
@@ -80,7 +84,7 @@ fn reward_payment_works() {
 		// Block author sets themselves as author
 		assert_ok!(Rewards::set_author(Origin::none(), 1, Perbill::zero()));
 		// Next block
-		next_block();
+		run_to_block(2);
 		// User gets reward
 		assert_eq!(Balances::free_balance(1), 54);
 
@@ -88,7 +92,71 @@ fn reward_payment_works() {
 		assert_ok!(Rewards::set_reward(Origin::root(), 42));
 		assert_ok!(Rewards::set_taxation(Origin::root(), Perbill::zero()));
 		assert_ok!(Rewards::set_author(Origin::none(), 2, Perbill::zero()));
-		next_block();
+		run_to_block(3);
 		assert_eq!(Balances::free_balance(2), 42);
+	});
+}
+
+#[test]
+fn reward_locks_work() {
+	new_test_ext().execute_with(|| {
+		// Block author sets themselves as author
+		assert_ok!(Rewards::set_author(Origin::none(), 1, Perbill::zero()));
+		// Next block
+		run_to_block(2);
+		// User gets reward
+		assert_eq!(Balances::free_balance(1), 54);
+		// 50 is locked, 4 is unlocked
+		assert_ok!(Balances::transfer(Origin::signed(1), 2, 4));
+
+		// Cannot transfer because of locks
+		assert_noop!(Balances::transfer(Origin::signed(1), 2, 5), BalancesError::<Test, _>::LiquidityRestrictions);
+
+		// Confirm locks (10 of them, each of value 5)
+		let mut expected_locks = (1..=10).map(|x| (x * 10 + 1, 5)).collect::<BTreeMap<_, _>>();
+		assert_eq!(Rewards::reward_locks(1), expected_locks);
+
+		// 10 blocks later (10 days)
+		run_to_block(11);
+		// User update locks
+		assert_ok!(Rewards::update_locks(Origin::signed(1)));
+		// Locks updated
+		expected_locks.remove(&11);
+		assert_eq!(Rewards::reward_locks(1), expected_locks);
+		// Transfer works
+		assert_ok!(Balances::transfer(Origin::signed(1), 2, 5));
+		// Cannot transfer more
+		assert_noop!(Balances::transfer(Origin::signed(1), 2, 1), BalancesError::<Test, _>::LiquidityRestrictions);
+
+		// User mints more blocks
+		assert_ok!(Rewards::set_author(Origin::none(), 1, Perbill::zero()));
+		run_to_block(12);
+		assert_ok!(Rewards::set_author(Origin::none(), 1, Perbill::zero()));
+		run_to_block(13);
+
+		// Locks as expected
+		// Left over from block 1 + from block 11
+		let mut expected_locks = (2..=10).map(|x| (x * 10 + 1, 10)).collect::<BTreeMap<_, _>>();
+		// Last one from block 11
+		expected_locks.insert(111, 5);
+		// From block 12
+		expected_locks.append(&mut (2..=11).map(|x| (x * 10 + 2, 5)).collect::<BTreeMap<_, _>>());
+		assert_eq!(Rewards::reward_locks(1), expected_locks);
+
+		// User gains 8 free from the rewards
+		assert_ok!(Balances::transfer(Origin::signed(1), 2, 8));
+		assert_noop!(Balances::transfer(Origin::signed(1), 2, 1), BalancesError::<Test, _>::LiquidityRestrictions);
+
+		// 10 more is unlocked on block 21
+		run_to_block(21);
+		assert_ok!(Rewards::update_locks(Origin::signed(1)));
+		assert_ok!(Balances::transfer(Origin::signed(1), 2, 10));
+		// 5 more unlocked on block 22
+		run_to_block(22);
+		assert_ok!(Rewards::update_locks(Origin::signed(1)));
+		assert_ok!(Balances::transfer(Origin::signed(1), 2, 5));
+
+		// Cannot transfer more
+		assert_noop!(Balances::transfer(Origin::signed(1), 2, 1), BalancesError::<Test, _>::LiquidityRestrictions);
 	});
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -332,12 +332,13 @@ impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 		let locked_reward = total_reward.saturating_sub(1 * DOLLARS);
 
 		if locked_reward > 0 {
+			const TOTAL_LOCK_PERIOD: BlockNumber = 100 * DAYS;
 			const DIVIDE: BlockNumber = 10;
 
 			for i in 0..DIVIDE {
 				let one_locked_reward = locked_reward / DIVIDE as u128;
 
-				let estimate_block_number = current_block + (i + 1) * DIVIDE * DAYS;
+				let estimate_block_number = current_block + (i + 1) * (TOTAL_LOCK_PERIOD / DIVIDE);
 				let actual_block_number = estimate_block_number / DAYS * DAYS;
 
 				locks.insert(actual_block_number, one_locked_reward);


### PR DESCRIPTION
This add tests for reward locks.

One superficial change is added which adds `TOTAL_LOCK_PERIOD` rather than assuming that number of unlock periods is the same as number of days.

So you could configure 60 days unlocking over 10 periods for example.