### PR TITLE
Rename dispatchable update_locks -> unlock

### DIFF
--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -152,11 +152,11 @@ decl_module! {
 		}
 
 		#[weight = T::DbWeight::get().reads_writes(1, 1)]
-		fn update_locks(origin) {
-			let account = ensure_signed(origin)?;
-			let locks = Self::reward_locks(&account);
+		fn unlock(origin, target: T::AccountId) {
+			ensure_signed(origin)?;
 
-			Self::do_update_locks(account, locks);
+			let locks = Self::reward_locks(&target);
+			Self::do_update_locks(target, locks);
 		}
 
 		fn on_initialize(now: T::BlockNumber) -> Weight {

--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -140,7 +140,7 @@ fn reward_locks_work() {
 		// 10 blocks later (10 days)
 		System::set_block_number(11);
 		// User update locks
-		assert_ok!(Rewards::update_locks(Origin::signed(1)));
+		assert_ok!(Rewards::unlock(Origin::signed(1), 1));
 		// Locks updated
 		expected_locks.remove(&11);
 		assert_eq!(Rewards::reward_locks(1), expected_locks);
@@ -170,11 +170,11 @@ fn reward_locks_work() {
 
 		// 20 more is unlocked on block 21
 		System::set_block_number(21);
-		assert_ok!(Rewards::update_locks(Origin::signed(1)));
+		assert_ok!(Rewards::unlock(Origin::signed(1), 1));
 		assert_ok!(Balances::transfer(Origin::signed(1), 2, 20));
 		// 10 more unlocked on block 22
 		System::set_block_number(22);
-		assert_ok!(Rewards::update_locks(Origin::signed(1)));
+		assert_ok!(Rewards::unlock(Origin::signed(1), 1));
 		assert_ok!(Balances::transfer(Origin::signed(1), 2, 10));
 
 		// Cannot transfer more


### PR DESCRIPTION
Keep it consistent naming as in `democracy.unlock`. Also allows any signed account to call it to update other accounts' locks.