### PR TITLE
Benchmarks for Reward Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,6 +4009,7 @@ dependencies = [
 name = "pallet-rewards"
 version = "2.1.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ wasmtime = [
 	"sc-service/wasmtime",
 ]
 runtime-benchmarks = [
+	"wasmtime",
 	"kulupu-runtime/runtime-benchmarks",
 ]
 

--- a/frame/rewards/Cargo.toml
+++ b/frame/rewards/Cargo.toml
@@ -14,6 +14,9 @@ sp-consensus-pow = { path = "../../vendor/substrate/primitives/consensus/pow", d
 frame-support = { path = "../../vendor/substrate/frame/support", default-features = false }
 frame-system = { path = "../../vendor/substrate/frame/system", default-features = false }
 
+# Benchmarking
+frame-benchmarking = { path = "../../vendor/substrate/frame/benchmarking", default-features = false, optional = true }
+
 [dev-dependencies]
 sp-core = { path = "../../vendor/substrate/primitives/core", default-features = false }
 sp-io = { path = "../../vendor/substrate/primitives/io", default-features = false }
@@ -30,4 +33,8 @@ std = [
 	"sp-consensus-pow/std",
 	"frame-support/std",
 	"frame-system/std",
+]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-support/runtime-benchmarks",
 ]

--- a/frame/rewards/src/benchmarking.rs
+++ b/frame/rewards/src/benchmarking.rs
@@ -45,11 +45,13 @@ fn create_locks<T: Trait>(who: &T::AccountId, num_of_locks: u32) {
 benchmarks! {
 	_ { }
 
+	// Constant time
 	note_author_prefs { }: _(RawOrigin::None, Perbill::from_percent(50))
 	verify {
 		assert!(AuthorDonation::exists());
 	}
 
+	// Constant time
 	set_reward {
 		let new_reward = BalanceOf::<T>::max_value();
 	}: _(RawOrigin::Root, new_reward)
@@ -57,6 +59,7 @@ benchmarks! {
 		assert_last_event::<T>(Event::<T>::RewardChanged(new_reward).into());
 	}
 
+	// Constant time
 	set_taxation {
 		let new_taxation = Perbill::from_percent(50);
 	}: _(RawOrigin::Root, new_taxation)
@@ -64,6 +67,7 @@ benchmarks! {
 		assert_last_event::<T>(Event::<T>::TaxationChanged(new_taxation).into());
 	}
 
+	// Worst case: Target user has `max_locks` which are all unlocked during this call.
 	unlock {
 		let miner = account("miner", 0, 0);
 		let max_locks = T::GenerateRewardLocks::max_locks();
@@ -76,6 +80,7 @@ benchmarks! {
 		assert_eq!(RewardLocks::<T>::get(&miner).iter().count(), 0);
 	}
 
+	// Worst case: Author info is in digest.
 	on_initialize {
 		let author: T::AccountId = account("author", 0, 0);
 		let author_digest = DigestItemOf::<T>::PreRuntime(sp_consensus_pow::POW_ENGINE_ID, author.encode());

--- a/frame/rewards/src/benchmarking.rs
+++ b/frame/rewards/src/benchmarking.rs
@@ -1,0 +1,79 @@
+// Copyright 2020 Wei Tang.
+// This file is part of Kulupu.
+
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Benchmarking for Rewards pallet.
+
+use super::*;
+use frame_system::{RawOrigin, EventRecord};
+use frame_benchmarking::{benchmarks, account, whitelisted_caller};
+use sp_runtime::traits::Bounded;
+
+fn assert_last_event<T: Trait>(generic_event: <T as Trait>::Event) {
+	let events = frame_system::Module::<T>::events();
+	let system_event: <T as frame_system::Trait>::Event = generic_event.into();
+	// compare to the last event record
+	let EventRecord { event, .. } = &events[events.len() - 1];
+	assert_eq!(event, &system_event);
+}
+
+fn create_locks<T: Trait>(who: T::AccountId, num_of_locks: u32) {
+
+}
+
+benchmarks! {
+	_ { }
+
+	note_author_prefs { }: _(RawOrigin::None, Perbill::from_percent(50))
+	verify {
+		assert!(AuthorDonation::exists());
+	}
+
+	set_reward {
+		let new_reward = BalanceOf::<T>::max_value();
+	}: _(RawOrigin::Root, new_reward)
+	verify {
+		assert_last_event::<T>(Event::<T>::RewardChanged(new_reward).into());
+	}
+
+	set_taxation {
+		let new_taxation = Perbill::from_percent(50);
+	}: _(RawOrigin::Root, new_taxation)
+	verify {
+		assert_last_event::<T>(Event::<T>::TaxationChanged(new_taxation).into());
+	}
+
+	// unlock {
+	// 	let miner = caller("miner", 0, 0);
+	// 	let MAX_LOCKS = 1000;
+	// 	create_locks::<T>(miner, MAX_LOCKS);
+	// }
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{new_test_ext, Test};
+	use frame_support::assert_ok;
+
+	#[test]
+	fn test_benchmarks() {
+		new_test_ext(0).execute_with(|| {
+			assert_ok!(test_benchmark_note_author_prefs::<Test>());
+			assert_ok!(test_benchmark_set_reward::<Test>());
+			assert_ok!(test_benchmark_set_taxation::<Test>());
+		});
+	}
+}

--- a/frame/rewards/src/benchmarking.rs
+++ b/frame/rewards/src/benchmarking.rs
@@ -80,6 +80,10 @@ benchmarks! {
 		let author: T::AccountId = account("author", 0, 0);
 		let author_digest = DigestItemOf::<T>::PreRuntime(sp_consensus_pow::POW_ENGINE_ID, author.encode());
 		frame_system::Module::<T>::deposit_log(author_digest);
+
+		// Whitelist transient storage items
+		frame_benchmarking::benchmarking::add_to_whitelist(Author::<T>::hashed_key().to_vec().into());
+
 		let block_number = frame_system::Module::<T>::block_number();
 	}: { crate::Module::<T>::on_initialize(block_number); }
 	verify {
@@ -107,6 +111,10 @@ benchmarks! {
 		// Move to a point where all locks would unlock.
 		frame_system::Module::<T>::set_block_number(max_locks.into());
 		assert_eq!(RewardLocks::<T>::get(&author).iter().count() as u32, max_locks);
+
+		// Whitelist transient storage items
+		frame_benchmarking::benchmarking::add_to_whitelist(Author::<T>::hashed_key().to_vec().into());
+		frame_benchmarking::benchmarking::add_to_whitelist(AuthorDonation::hashed_key().to_vec().into());
 
 		let block_number = frame_system::Module::<T>::block_number();
 	}: { crate::Module::<T>::on_finalize(block_number); }

--- a/frame/rewards/src/benchmarking.rs
+++ b/frame/rewards/src/benchmarking.rs
@@ -17,8 +17,9 @@
 //! Benchmarking for Rewards pallet.
 
 use super::*;
-use frame_system::{RawOrigin, EventRecord};
+use frame_system::{RawOrigin, EventRecord, DigestItemOf};
 use frame_benchmarking::{benchmarks, account, whitelisted_caller};
+use frame_support::traits::{OnInitialize, OnFinalize};
 use sp_runtime::traits::Bounded;
 
 fn assert_last_event<T: Trait>(generic_event: <T as Trait>::Event) {
@@ -68,11 +69,51 @@ benchmarks! {
 		let max_locks = T::GenerateRewardLocks::max_locks();
 		create_locks::<T>(&miner, max_locks);
 		let caller = whitelisted_caller();
-		frame_system::Module::<T>::set_block_number(T::BlockNumber::max_value());
+		frame_system::Module::<T>::set_block_number(max_locks.into());
 		assert_eq!(RewardLocks::<T>::get(&miner).iter().count() as u32, max_locks);
 	}: _(RawOrigin::Signed(caller), miner.clone())
 	verify {
 		assert_eq!(RewardLocks::<T>::get(&miner).iter().count(), 0);
+	}
+
+	on_initialize {
+		let author: T::AccountId = account("author", 0, 0);
+		let author_digest = DigestItemOf::<T>::PreRuntime(sp_consensus_pow::POW_ENGINE_ID, author.encode());
+		frame_system::Module::<T>::deposit_log(author_digest);
+		let block_number = frame_system::Module::<T>::block_number();
+	}: { crate::Module::<T>::on_initialize(block_number); }
+	verify {
+		assert_eq!(Author::<T>::get(), Some(author));
+	}
+
+	// Worst case: This author already has `max_locks` locked up, produces a new block, and we unlock
+	// everything in addition to creating brand new locks for the new reward.
+	on_finalize {
+		let author: T::AccountId = account("author", 0, 0);
+		let donation = Perbill::from_percent(50);
+		let reward = BalanceOf::<T>::max_value();
+		let taxation = Perbill::from_percent(50);
+
+		// Setup pallet variables
+		Author::<T>::put(&author);
+		AuthorDonation::put(donation);
+		Reward::<T>::put(reward);
+		Taxation::put(taxation);
+
+		// Create existing locks on author.
+		let max_locks = T::GenerateRewardLocks::max_locks();
+		create_locks::<T>(&author, max_locks);
+
+		// Move to a point where all locks would unlock.
+		frame_system::Module::<T>::set_block_number(max_locks.into());
+		assert_eq!(RewardLocks::<T>::get(&author).iter().count() as u32, max_locks);
+
+		let block_number = frame_system::Module::<T>::block_number();
+	}: { crate::Module::<T>::on_finalize(block_number); }
+	verify {
+		assert!(Author::<T>::get().is_none());
+		assert!(AuthorDonation::get().is_none());
+		assert!(RewardLocks::<T>::get(&author).iter().count() > 0);
 	}
 }
 
@@ -89,6 +130,8 @@ mod tests {
 			assert_ok!(test_benchmark_set_reward::<Test>());
 			assert_ok!(test_benchmark_set_taxation::<Test>());
 			assert_ok!(test_benchmark_unlock::<Test>());
+			assert_ok!(test_benchmark_on_initialize::<Test>());
+			assert_ok!(test_benchmark_on_finalize::<Test>());
 		});
 	}
 }

--- a/frame/rewards/src/default_weights.rs
+++ b/frame/rewards/src/default_weights.rs
@@ -23,30 +23,30 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
 impl crate::WeightInfo for () {
 	fn note_author_prefs() -> Weight {
-		(16000000 as Weight)
+		(9845000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_reward() -> Weight {
-		(54000000 as Weight)
+		(32396000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_taxation() -> Weight {
-		(51000000 as Weight)
+		(29935000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn unlock() -> Weight {
-		(104000000 as Weight)
+		(76658000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn on_initialize() -> Weight {
-		(20000000 as Weight)
+		(12159000 as Weight)
 	}
 	fn on_finalize() -> Weight {
-		(335000000 as Weight)
+		(224231000 as Weight)
 			.saturating_add(DbWeight::get().reads(5 as Weight))
 			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}

--- a/frame/rewards/src/default_weights.rs
+++ b/frame/rewards/src/default_weights.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 Wei Tang.
+// This file is part of Kulupu.
+
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0-rc6
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+impl crate::WeightInfo for () {
+	fn note_author_prefs() -> Weight {
+		(16000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn set_reward() -> Weight {
+		(54000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn set_taxation() -> Weight {
+		(51000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn unlock() -> Weight {
+		(104000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn on_initialize() -> Weight {
+		(20000000 as Weight)
+	}
+	fn on_finalize() -> Weight {
+		(335000000 as Weight)
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+}

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -22,6 +22,8 @@
 mod mock;
 #[cfg(test)]
 mod tests;
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
 
 use codec::{Encode, Decode};
 use sp_std::{result, cmp::min, prelude::*, collections::btree_map::BTreeMap};

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -187,11 +187,10 @@ decl_module! {
 			0
 		}
 
-		fn on_finalize() {
+		fn on_finalize(now: T::BlockNumber) {
 			if let Some(author) = <Self as Store>::Author::get() {
 				let reward = Reward::<T>::get();
-				let current_number = frame_system::Module::<T>::block_number();
-				Self::do_reward(&author, reward, current_number);
+				Self::do_reward(&author, reward, now);
 			}
 
 			<Self as Store>::Author::kill();

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -121,7 +121,7 @@ impl crate::GenerateRewardLocks<Test> for GenerateRewardLocks {
 			for i in 0..DIVIDE {
 				let one_locked_reward = locked_reward / DIVIDE as u128;
 
-				let estimate_block_number = current_block + (i + 1) * (TOTAL_LOCK_PERIOD / DIVIDE);
+				let estimate_block_number = current_block.saturating_add((i + 1) * (TOTAL_LOCK_PERIOD / DIVIDE));
 				let actual_block_number = estimate_block_number / DAYS * DAYS;
 
 				locks.insert(actual_block_number, one_locked_reward);

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -142,6 +142,7 @@ impl Trait for Test {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
+	type WeightInfo = ();
 }
 
 pub type System = frame_system::Module<Test>;

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -130,6 +130,11 @@ impl crate::GenerateRewardLocks<Test> for GenerateRewardLocks {
 
 		locks
 	}
+
+	fn max_locks() -> u32 {
+		// Max locks when one unlocks everyday for the `TOTAL_LOCK_PERIOD`.
+		100
+	}
 }
 
 impl Trait for Test {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -120,4 +120,6 @@ runtime-benchmarks = [
 	"proxy/runtime-benchmarks",
 	"vesting/runtime-benchmarks",
 	"multisig/runtime-benchmarks",
+	# Kulupu specific pallets
+	"rewards/runtime-benchmarks",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -347,6 +347,11 @@ impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 
 		locks
 	}
+
+	fn max_locks() -> u32 {
+		// Max locks when one unlocks everyday for `TOTAL_LOCK_PERIOD`.
+		100
+	}
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -338,7 +338,7 @@ impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 			for i in 0..DIVIDE {
 				let one_locked_reward = locked_reward / DIVIDE as u128;
 
-				let estimate_block_number = current_block + (i + 1) * (TOTAL_LOCK_PERIOD / DIVIDE);
+				let estimate_block_number = current_block.saturating_add((i + 1) * (TOTAL_LOCK_PERIOD / DIVIDE));
 				let actual_block_number = estimate_block_number / DAYS * DAYS;
 
 				locks.insert(actual_block_number, one_locked_reward);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,6 +21,7 @@
 #![recursion_limit="256"]
 
 mod fee;
+mod weights;
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -363,6 +364,7 @@ impl rewards::Trait for Runtime {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
+	type WeightInfo = weights::rewards::WeightInfo;
 }
 
 pub struct Author;
@@ -876,6 +878,8 @@ impl_runtime_apis! {
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
 				// System Events
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
+				// System Digest
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef799e7f93fc6a98f0874fd057f111c4d2d").to_vec().into(),
 				// Treasury Account
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec().into(),
 			];

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -858,36 +858,30 @@ impl_runtime_apis! {
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn dispatch_benchmark(
-			pallet: Vec<u8>,
-			benchmark: Vec<u8>,
-			lowest_range_values: Vec<u32>,
-			highest_range_values: Vec<u32>,
-			steps: Vec<u32>,
-			repeat: u32,
-			extra: bool,
+			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
+			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
 			use frame_system_benchmarking::Module as SystemBench;
 
 			impl frame_system_benchmarking::Trait for Runtime {}
 
-			let whitelist: Vec<Vec<u8>> = vec![
+			let whitelist: Vec<TrackedStorageKey> = vec![
 				// Block Number
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
 				// Total Issuance
-				hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec(),
+				hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec().into(),
 				// Execution Phase
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec().into(),
 				// Event Count
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
 				// System Events
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
 				// Treasury Account
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec().into(),
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
-			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist, extra);
+			let params = (&config, &whitelist);
 
 			add_benchmark!(params, batches, balances, Balances);
 			add_benchmark!(params, batches, collective, Council);
@@ -902,6 +896,8 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, treasury, Treasury);
 			add_benchmark!(params, batches, utility, Utility);
 			add_benchmark!(params, batches, vesting, Vesting);
+
+			add_benchmark!(params, batches, rewards, Rewards);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -350,7 +350,7 @@ impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 	}
 
 	fn max_locks() -> u32 {
-		// Max locks when one unlocks everyday for `TOTAL_LOCK_PERIOD`.
+		// Max locks when for 10 consecutive days, 10 incremental locks are created.
 		100
 	}
 }

--- a/runtime/src/weights/mod.rs
+++ b/runtime/src/weights/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2020 Wei Tang.
+// This file is part of Kulupu.
+
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Weights for pallets used in this runtime.
+
+pub mod rewards;

--- a/runtime/src/weights/rewards.rs
+++ b/runtime/src/weights/rewards.rs
@@ -24,30 +24,30 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 pub struct WeightInfo;
 impl rewards::WeightInfo for WeightInfo {
 	fn note_author_prefs() -> Weight {
-		(16000000 as Weight)
+		(9845000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_reward() -> Weight {
-		(54000000 as Weight)
+		(32396000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_taxation() -> Weight {
-		(51000000 as Weight)
+		(29935000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn unlock() -> Weight {
-		(104000000 as Weight)
+		(76658000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn on_initialize() -> Weight {
-		(20000000 as Weight)
+		(12159000 as Weight)
 	}
 	fn on_finalize() -> Weight {
-		(335000000 as Weight)
+		(224231000 as Weight)
 			.saturating_add(DbWeight::get().reads(5 as Weight))
 			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}

--- a/runtime/src/weights/rewards.rs
+++ b/runtime/src/weights/rewards.rs
@@ -1,0 +1,54 @@
+// Copyright 2020 Wei Tang.
+// This file is part of Kulupu.
+
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0-rc6
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+pub struct WeightInfo;
+impl rewards::WeightInfo for WeightInfo {
+	fn note_author_prefs() -> Weight {
+		(16000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn set_reward() -> Weight {
+		(54000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn set_taxation() -> Weight {
+		(51000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn unlock() -> Weight {
+		(104000000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn on_initialize() -> Weight {
+		(20000000 as Weight)
+	}
+	fn on_finalize() -> Weight {
+		(335000000 as Weight)
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+}


### PR DESCRIPTION
This adds benchmarks to the rewards pallet.

The introduced `WeightInfo` trait is:

```rust
pub trait WeightInfo {
	fn note_author_prefs() -> Weight;
	fn set_reward() -> Weight;
	fn set_taxation() -> Weight;
	fn unlock() -> Weight;
	fn on_initialize() -> Weight;
	fn on_finalize() -> Weight;
}
```

And defines weights for all the extrinsics (and functions) in this runtime.

## Changes

* Introduced `fn max_locks() -> u32;` function to the `GenerateRewardLocks` trait. This allows our benchmarks to know the upper bound number of locks that can exist for a user in order to accurately benchmark the `unlock` and `on_finalize` functions. We always assume worst case, which is that the block author/target user always has a `max_locks` number of locks when triggering one of these functions.

* Fixed potential overflow when generating locks close to the block number limit:

```
let estimate_block_number = current_block + (i + 1) * (TOTAL_LOCK_PERIOD / DIVIDE);
```

* Refactored the reward logic into `do_reward`.
    * Fixed potential overflow here:

```
/// Old Code
for (new_lock_number, new_lock_balance) in miner_reward_locks {
	*locks.entry(new_lock_number).or_default() += new_lock_balance;
}
```

* `do_update_locks` accepts block number as a param to avoid double lookup when not needed (from `do_reward`).
    * Fixed potential overflow `total_locked += *locked_balance;`
* Updated benchmarking pipeline to latest substrate.
* Added + executed + integrated benchmarks to all Reward Pallet functions.

## Benchmark Info

```bash
cargo build --release --features runtime-benchmarks
./target/release/kulupu benchmark --chain dev --steps 50 --repeat 20 --pallet rewards --extrinsic "*" --raw --execution=wasm --wasm-execution=compiled --output
```

Executed on standard Substrate benchmarking machine.

<details>
<summary>Full Benchmark Output</summary>

```
Pallet: "rewards", Extrinsic: "note_author_prefs", Lowest values: [], Highest values: [], Steps: [50], Repeat: 20
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes
10851,7645,1,0,1,0
15098,3591,1,0,1,0
10406,3310,1,0,1,0
10084,3346,1,0,1,0
9985,3355,1,0,1,0
9880,3248,1,0,1,0
10138,3289,1,0,1,0
9923,3254,1,0,1,0
9986,3217,1,0,1,0
9825,3273,1,0,1,0
9978,3229,1,0,1,0
9887,3191,1,0,1,0
9863,3250,1,0,1,0
9967,3253,1,0,1,0
9882,3310,1,0,1,0
9918,3263,1,0,1,0
9919,3252,1,0,1,0
9931,3207,1,0,1,0
9907,3253,1,0,1,0
9897,3233,1,0,1,0

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=    9.931
              µs

Reads = 1
Writes = 1
Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=    9.931
              µs

Reads = 1
Writes = 1
Pallet: "rewards", Extrinsic: "set_reward", Lowest values: [], Highest values: [], Steps: [50], Repeat: 20
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes
33496,3662,1,4,1,2
33058,3553,1,4,1,2
32573,3511,1,4,1,2
32421,3441,1,4,1,2
32623,3563,1,4,1,2
32595,3428,1,4,1,2
32575,3441,1,4,1,2
32458,3457,1,4,1,2
32757,3392,1,4,1,2
32352,3373,1,4,1,2
32700,3428,1,4,1,2
32510,3558,1,4,1,2
32219,3508,1,4,1,2
32248,3502,1,4,1,2
32418,3390,1,4,1,2
32373,3494,1,4,1,2
32319,3443,1,4,1,2
32494,3482,1,4,1,2
32530,3460,1,4,1,2
32614,3481,1,4,1,2

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=    32.53
              µs

Reads = 1
Writes = 1
Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=    32.53
              µs

Reads = 1
Writes = 1
Pallet: "rewards", Extrinsic: "set_taxation", Lowest values: [], Highest values: [], Steps: [50], Repeat: 20
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes
30874,3641,1,4,1,2
30632,3490,1,4,1,2
30302,3559,1,4,1,2
29997,3482,1,4,1,2
30329,3411,1,4,1,2
30093,3472,1,4,1,2
29878,3526,1,4,1,2
30299,3549,1,4,1,2
30013,3527,1,4,1,2
29987,3498,1,4,1,2
30164,3540,1,4,1,2
29815,3453,1,4,1,2
30657,3527,1,4,1,2
30125,3426,1,4,1,2
30181,3419,1,4,1,2
30200,3424,1,4,1,2
30082,3437,1,4,1,2
30673,3572,1,4,1,2
30104,3444,1,4,1,2
30131,3425,1,4,1,2

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=    30.16
              µs

Reads = 1
Writes = 1
Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=    30.16
              µs

Reads = 1
Writes = 1
Pallet: "rewards", Extrinsic: "unlock", Lowest values: [], Highest values: [], Steps: [50], Repeat: 20
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes
77909,3742,1,1,1,0
79826,3619,1,1,1,0
77399,3542,1,1,1,0
76960,3451,1,1,1,0
77305,3448,1,1,1,0
77218,3561,1,1,1,0
77247,3554,1,1,1,0
77024,3565,1,1,1,0
76969,3521,1,1,1,0
76928,3550,1,1,1,0
76810,3505,1,1,1,0
76844,3500,1,1,1,0
76654,3522,1,1,1,0
76718,3486,1,1,1,0
76691,3471,1,1,1,0
77064,3517,1,1,1,0
77040,3512,1,1,1,0
77162,3480,1,1,1,0
76770,3437,1,1,1,0
76773,3471,1,1,1,0

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=    77.02
              µs

Reads = 1
Writes = 1
Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=    77.02
              µs

Reads = 1
Writes = 1
Pallet: "rewards", Extrinsic: "on_initialize", Lowest values: [], Highest values: [], Steps: [50], Repeat: 20
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes
12930,3471,0,1,0,1
12515,3380,0,1,0,1
12396,3439,0,1,0,1
12383,3403,0,1,0,1
12547,3553,0,1,0,1
12274,3461,0,1,0,1
12263,3441,0,1,0,1
12274,3366,0,1,0,1
12166,3445,0,1,0,1
12143,3417,0,1,0,1
12362,3356,0,1,0,1
12455,3324,0,1,0,1
12378,3362,0,1,0,1
12306,3351,0,1,0,1
12219,3308,0,1,0,1
12278,3350,0,1,0,1
12145,3405,0,1,0,1
12248,3387,0,1,0,1
12175,3351,0,1,0,1
12327,3328,0,1,0,1

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=     12.3
              µs

Reads = 0
Writes = 0
Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=     12.3
              µs

Reads = 0
Writes = 0
Pallet: "rewards", Extrinsic: "on_finalize", Lowest values: [], Highest values: [], Steps: [50], Repeat: 20
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes
226202,4008,5,11,3,6
226218,4007,5,11,3,6
226401,3983,5,11,3,6
225103,3960,5,11,3,6
224522,3896,5,11,3,6
225598,3991,5,11,3,6
226067,3888,5,11,3,6
225001,3887,5,11,3,6
225623,3991,5,11,3,6
225855,3957,5,11,3,6
224909,3889,5,11,3,6
228120,3829,5,11,3,6
224772,3919,5,11,3,6
226387,3953,5,11,3,6
226270,3888,5,11,3,6
226146,3992,5,11,3,6
225977,3957,5,11,3,6
224817,3954,5,11,3,6
224817,3838,5,11,3,6
225592,3913,5,11,3,6

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=    225.8
              µs

Reads = 5
Writes = 3
Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=    225.8
              µs

Reads = 5
Writes = 3
```

</details>