### PR TITLE
Standardize all copyright headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kulupu"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
 build = "build.rs"
 edition = "2018"
 

--- a/frame/difficulty/Cargo.toml
+++ b/frame/difficulty/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-difficulty"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
 edition = "2018"
 description = "Difficulty adjustment module for Kulupu."
 

--- a/frame/difficulty/src/lib.rs
+++ b/frame/difficulty/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Difficulty adjustment module.
 

--- a/frame/eras/Cargo.toml
+++ b/frame/eras/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-eras"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
 edition = "2018"
 description = "Era information recording for later use."
 

--- a/frame/eras/src/lib.rs
+++ b/frame/eras/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Era information recording.
 

--- a/frame/rewards/Cargo.toml
+++ b/frame/rewards/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-rewards"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
 edition = "2018"
 
 [dependencies]

--- a/frame/rewards/src/benchmarking.rs
+++ b/frame/rewards/src/benchmarking.rs
@@ -1,18 +1,21 @@
-// Copyright 2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+// Copyright (c) 2020 Shawn Tabrizi.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Benchmarking for Rewards pallet.
 

--- a/frame/rewards/src/default_weights.rs
+++ b/frame/rewards/src/default_weights.rs
@@ -1,18 +1,21 @@
-// Copyright 2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+// Copyright (c) 2020 Shawn Tabrizi.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0-rc6
 

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Reward handling module for Kulupu.
 

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -1,18 +1,21 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+// Copyright (c) 2020 Shawn Tabrizi.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Mock runtime for tests
 

--- a/frame/rewards/src/tests.rs
+++ b/frame/rewards/src/tests.rs
@@ -1,18 +1,21 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+// Copyright (c) 2020 Shawn Tabrizi.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Tests for Rewards Pallet
 

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kulupu-pow"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
 edition = "2018"
 
 [dependencies]

--- a/pow/randomx/Cargo.toml
+++ b/pow/randomx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kulupu-randomx"
 description = "Proof-of-work (PoW) algorithm that is optimized for general-purpose CPUs"
-license = "BSD-3-Clause"
+license = "GPL-3.0-or-later"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
 edition = "2018"

--- a/pow/randomx/benches/fullvm.rs
+++ b/pow/randomx/benches/fullvm.rs
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Kulupu.
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
+
 use criterion::{Criterion, criterion_group, criterion_main};
 
 use randomx::{VM, FullVM};

--- a/pow/randomx/src/lib.rs
+++ b/pow/randomx/src/lib.rs
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Kulupu.
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
+
 use std::sync::Arc;
 use std::marker::PhantomData;
 

--- a/pow/randomx/sys/Cargo.toml
+++ b/pow/randomx/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kulupu-randomx-sys"
 description = "FFI bindings for RandomX"
-license = "BSD-3-Clause"
+license = "GPL-3.0-or-later"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
 edition = "2018"

--- a/pow/randomx/sys/src/lib.rs
+++ b/pow/randomx/sys/src/lib.rs
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Kulupu.
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/pow/src/compute/mod.rs
+++ b/pow/src/compute/mod.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 mod v1;
 mod v2;

--- a/pow/src/compute/v1.rs
+++ b/pow/src/compute/v1.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 use codec::{Encode, Decode};
 use sp_core::H256;

--- a/pow/src/compute/v2.rs
+++ b/pow/src/compute/v2.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 use codec::{Encode, Decode};
 use sp_core::{H256, crypto::Pair, hashing::blake2_256};

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod compute;
 pub mod weak_sub;

--- a/pow/src/weak_sub.rs
+++ b/pow/src/weak_sub.rs
@@ -1,19 +1,21 @@
-// Copyright 2020 Wei Tang.
-// Copyright 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+// Copyright (c) 2020 Parity Technologies (UK) Ltd.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
 	sync::Arc, collections::HashMap, marker::PhantomData, fmt::Debug,

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kulupu-primitives"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
 edition = "2018"
 
 [dependencies]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Kulupu primitive constants and types.
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kulupu-runtime"
 version = "2.2.0"
 authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
 edition = "2018"
 
 [dependencies]

--- a/runtime/src/fee.rs
+++ b/runtime/src/fee.rs
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Kulupu.
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
+
 use sp_runtime::Perbill;
 use frame_support::weights::{WeightToFeePolynomial, WeightToFeeCoefficient, WeightToFeeCoefficients};
 use kulupu_primitives::CENTS;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! The Kulupu runtime. This can be compiled with `#[no_std]`, ready for Wasm.
 

--- a/runtime/src/weights/mod.rs
+++ b/runtime/src/weights/mod.rs
@@ -1,18 +1,21 @@
-// Copyright 2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+// Copyright (c) 2020 Shawn Tabrizi.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Weights for pallets used in this runtime.
 

--- a/runtime/src/weights/rewards.rs
+++ b/runtime/src/weights/rewards.rs
@@ -1,18 +1,21 @@
-// Copyright 2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+// Copyright (c) 2020 Shawn Tabrizi.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0-rc6
 

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 use serde_json::json;
 use sp_core::{U256, crypto::UncheckedFrom};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 use sc_cli::RunCmd;
 use structopt::StructOpt;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 use std::{path::PathBuf, fs::File, io::Write};
 use log::info;

--- a/src/eras.rs
+++ b/src/eras.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 use serde::{Serialize, Deserialize};
 use sp_core::{H256, U256};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Kulupu CLI library.
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,18 +1,20 @@
-// Copyright 2019-2020 Wei Tang.
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This file is part of Kulupu.
-
+//
+// Copyright (c) 2019-2020 Wei Tang.
+//
 // Kulupu is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-
+//
 // Kulupu is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-
+//
 // You should have received a copy of the GNU General Public License
-// along with Kulupu.  If not, see <http://www.gnu.org/licenses/>.
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
 
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 


### PR DESCRIPTION
* As a convention, put `SPDX-License-Identifier` into the first line so that it can be easily parsed by other programs.
* We do not have any CLA, so everyone who contributes reserves their copyright, and those who contributes significantly should also be in the copyright header. Added several missing ones for @shawntabrizi.