### PR TITLE
Update to Substrate master and remove git submodule vendoring

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/substrate"]
-	path = vendor/substrate
-	url = https://github.com/paritytech/substrate
 [submodule "pow/randomx/sys/randomx"]
 	path = pow/randomx/sys/randomx
 	url = https://github.com/kulupu/randomx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,15 +268,15 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
 dependencies = [
  "async-global-executor",
  "async-io",
  "async-mutex",
  "blocking",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1466,7 +1466,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4008,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4086,7 +4086,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4104,7 +4104,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5327,7 +5327,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -5351,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5368,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5389,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5400,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5444,7 +5444,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5455,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5492,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5522,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5533,7 +5533,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5578,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5591,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-pow"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "futures 0.3.7",
@@ -5615,7 +5615,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -5639,7 +5639,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5653,7 +5653,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5682,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "log",
@@ -5699,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5714,7 +5714,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5732,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.7",
@@ -5787,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5826,7 +5826,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -5895,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5922,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "libp2p",
@@ -5935,7 +5935,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "hash-db",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "futures 0.3.7",
@@ -6001,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -6019,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "directories",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "erased-serde",
  "log",
@@ -6137,7 +6137,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "futures 0.3.7",
@@ -6158,7 +6158,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "futures 0.3.7",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "log",
@@ -6564,7 +6564,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6579,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6603,7 +6603,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6616,7 +6616,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6627,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6639,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "lru 0.4.3",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "serde",
  "serde_json",
@@ -6665,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6711,7 +6711,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6723,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6744,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6788,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6835,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6847,7 +6847,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "hash-db",
@@ -6871,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6882,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6898,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6910,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6921,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6931,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "backtrace",
  "log",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "serde",
  "sp-core",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6971,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6987,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "serde",
  "serde_json",
@@ -7008,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7031,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "hash-db",
  "log",
@@ -7053,12 +7053,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7071,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "sp-core",
@@ -7084,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7111,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "derive_more",
  "futures 0.3.7",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7140,7 +7140,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "futures 0.3.7",
  "futures-core",
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "platforms",
 ]
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.7",
@@ -7316,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7330,7 +7330,8 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cab12167e32b38a62c5ea5825aa0874cde315f907a46aad2b05aa8ef3d862f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
- "gimli 0.22.0",
+ "gimli 0.23.0",
 ]
 
 [[package]]
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
  "block-cipher",
- "byteorder 1.3.4",
+ "byteorder",
  "opaque-debug 0.3.0",
 ]
 
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
+checksum = "29661b60bec623f0586702976ff4d0c9942dcb6723161c2df0eea78455cfedfb"
 dependencies = [
  "const-random",
 ]
@@ -95,10 +95,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.13"
+name = "ahash"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
+checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -134,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "approx"
@@ -170,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "asn1_der"
@@ -195,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -220,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.3.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
 dependencies = [
  "async-executor",
  "async-io",
@@ -233,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a027f4b662e59d7070791e33baafd36affe67388965701b50039db5ebb240d2"
+checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -270,7 +276,7 @@ dependencies = [
  "async-io",
  "async-mutex",
  "blocking",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -289,20 +295,21 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-tls"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df097e3f506bec0e1a24f06bb3c962c228f36671de841ff579cb99f371772634"
+checksum = "d85a97c4a0ecce878efd3f945f119c78a646d8975340bca0398f9bb05c30cc52"
 dependencies = [
- "futures 0.3.5",
+ "futures-core",
+ "futures-io",
  "rustls",
  "webpki",
- "webpki-roots 0.19.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -318,9 +325,12 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f46ca51dca4837f1520754d1c8c36636356b81553d928dc9c177025369a06e"
+checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+dependencies = [
+ "autocfg 1.0.1",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -353,15 +363,15 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.51"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
+checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.20.0",
+ "object 0.22.0",
  "rustc-demangle",
 ]
 
@@ -373,15 +383,15 @@ checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
@@ -389,7 +399,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "serde",
 ]
 
@@ -401,7 +411,7 @@ checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if",
+ "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
@@ -439,12 +449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitmask"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da9b3d9f6f585199287a473f4f8dfab6566cf827d15c00c219f53c645687ead"
-
-[[package]]
 name = "bitvec"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,15 +460,13 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
+checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
- "byte-tools",
- "byteorder 1.3.4",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -479,23 +481,23 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -507,7 +509,7 @@ checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding 0.1.5",
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder",
  "generic-array 0.12.3",
 ]
 
@@ -547,9 +549,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5aba2c74d15fe950254784fe497a999345606169c2288ccb771b72acdf41241"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
 dependencies = [
  "async-channel",
  "async-task",
@@ -567,9 +569,9 @@ checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bstr"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -597,12 +599,6 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-
-[[package]]
-name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
@@ -613,7 +609,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "either",
  "iovec",
 ]
@@ -623,12 +619,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cache-padded"
@@ -647,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 dependencies = [
  "jobserver",
 ]
@@ -670,12 +660,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chacha20"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
 dependencies = [
- "stream-cipher 0.7.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -688,7 +684,7 @@ dependencies = [
  "aead",
  "chacha20",
  "poly1305",
- "stream-cipher 0.7.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -769,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
 dependencies = [
  "const-random-macro",
  "proc-macro-hack",
@@ -779,13 +775,19 @@ dependencies = [
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.0",
  "proc-macro-hack",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -830,7 +832,7 @@ version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d9badfe36176cb653506091693bc2bb1970c9bddfcd6ec7fac404f7eaec6f38"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
@@ -909,11 +911,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -954,12 +956,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "crossbeam-utils",
- "maybe-uninit",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -968,9 +970,20 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -980,10 +993,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
+ "memoffset",
+ "scopeguard 1.1.0",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.0",
+ "lazy_static",
  "memoffset",
  "scopeguard 1.1.0",
 ]
@@ -994,8 +1021,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -1006,7 +1033,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+dependencies = [
+ "autocfg 1.0.1",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
@@ -1038,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
 dependencies = [
  "bstr",
  "csv-core",
@@ -1069,12 +1108,13 @@ dependencies = [
 
 [[package]]
 name = "cuckoofilter"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd43f7cfaffe0a386636a10baea2ee05cc50df3b77bea4a456c9572a939bf1f"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
 dependencies = [
- "byteorder 0.5.3",
- "rand 0.3.23",
+ "byteorder",
+ "fnv",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1083,7 +1123,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
  "subtle 2.3.0",
@@ -1096,7 +1136,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle 2.3.0",
@@ -1105,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "derive_more"
@@ -1144,7 +1184,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -1165,8 +1205,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
- "byteorder 1.3.4",
- "quick-error",
+ "byteorder",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -1192,15 +1232,15 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
+checksum = "d55796afa1b20c2945ca8eabfc421839f2b766619209f1ede813cf2484f31804"
 
 [[package]]
 name = "ed25519"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dfc993ea376e864fe29a4099a61ca0bb994c6d7745a61bf60ddb3d64e05237"
+checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
 dependencies = [
  "signature",
 ]
@@ -1215,7 +1255,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "zeroize",
 ]
 
@@ -1275,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eab5ee3df98a279d9b316b1af6ac95422127b1290317e6d18c1743c99418b01"
+checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1306,7 +1346,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
 ]
 
 [[package]]
@@ -1378,7 +1418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8feb87a63249689640ac9c011742c33139204e3c134293d3054022276869133b"
 dependencies = [
  "either",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 2.0.2",
  "log",
  "num-traits",
@@ -1392,7 +1432,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
@@ -1406,11 +1446,11 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -1426,6 +1466,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1433,6 +1474,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1450,16 +1492,20 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "chrono",
  "frame-benchmarking",
+ "handlebars",
  "parity-scale-codec",
  "sc-cli",
  "sc-client-db",
  "sc-executor",
  "sc-service",
+ "serde",
  "sp-core",
  "sp-externalities",
+ "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
  "structopt",
@@ -1468,6 +1514,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1483,6 +1530,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1493,8 +1541,9 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "bitmask",
+ "bitflags",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
@@ -1517,6 +1566,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1527,6 +1577,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1538,6 +1589,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1547,6 +1599,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1562,6 +1615,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1575,6 +1629,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1616,15 +1671,15 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1637,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1656,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
 
 [[package]]
 name = "futures-core-preview"
@@ -1672,7 +1727,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "num_cpus",
 ]
 
@@ -1682,21 +1737,21 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdcef58a173af8148b182684c9f2d5250875adbcaff7b5794073894f9d8634a9"
 dependencies = [
- "futures 0.1.29",
- "futures 0.3.5",
+ "futures 0.1.30",
+ "futures 0.3.7",
  "lazy_static",
  "log",
  "parking_lot 0.9.0",
- "pin-project",
+ "pin-project 0.4.27",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "futures-executor"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1706,15 +1761,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
 
 [[package]]
 name = "futures-lite"
-version = "1.10.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48d23e382e1f50ad68d16cd23dd3c467f420d4933b629c3f183f33e9f560d8"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1727,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1739,15 +1794,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
 dependencies = [
  "once_cell 1.4.1",
 ]
@@ -1766,11 +1821,11 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1778,7 +1833,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 1.0.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1804,9 +1859,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "memchr",
- "pin-project",
+ "pin-project 0.4.27",
 ]
 
 [[package]]
@@ -1814,6 +1869,19 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+
+[[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "generic-array"
@@ -1835,34 +1903,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+dependencies = [
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1889,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glob"
@@ -1901,9 +1958,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
+checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1931,10 +1988,10 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "bytes 0.4.12",
  "fnv",
- "futures 0.1.29",
+ "futures 0.1.30",
  "http 0.1.21",
  "indexmap",
  "log",
@@ -1945,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -1960,6 +2017,7 @@ dependencies = [
  "tokio 0.2.22",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1967,6 +2025,20 @@ name = "half"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+
+[[package]]
+name = "handlebars"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2764f9796c0ddca4b82c07f25dd2cb3db30b9a8f47940e78e1c883d9e95c3db9"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error 2.0.0",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "hash-db"
@@ -1989,7 +2061,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "scopeguard 0.3.3",
 ]
 
@@ -1999,7 +2071,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
- "ahash 0.2.18",
+ "ahash 0.2.19",
  "autocfg 0.1.7",
 ]
 
@@ -2018,6 +2090,9 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.6",
+]
 
 [[package]]
 name = "heck"
@@ -2030,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -2124,7 +2199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "http 0.1.21",
  "tokio-buf",
 ]
@@ -2157,7 +2232,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -2173,7 +2248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "futures-cpupool",
  "h2 0.1.26",
  "http 0.1.21",
@@ -2198,21 +2273,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.6",
+ "h2 0.2.7",
  "http 0.2.1",
  "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 1.0.1",
  "socket2",
  "tokio 0.2.22",
  "tower-service",
@@ -2229,7 +2304,7 @@ dependencies = [
  "bytes 0.5.6",
  "ct-logs",
  "futures-util",
- "hyper 0.13.8",
+ "hyper 0.13.9",
  "log",
  "rustls",
  "rustls-native-certs",
@@ -2258,6 +2333,27 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+dependencies = [
+ "if-addrs-sys",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "if-addrs-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2302,11 +2398,11 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2324,7 +2420,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 2.0.2",
 ]
 
@@ -2398,7 +2494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489b9c612e60c766f751ab40fcb43cbb55a1e10bb44a9b4307ed510ca598cbd7"
 dependencies = [
  "failure",
- "futures 0.1.29",
+ "futures 0.1.30",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -2413,7 +2509,7 @@ version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "log",
  "serde",
  "serde_derive",
@@ -2535,7 +2631,7 @@ version = "2.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "futures 0.3.5",
+ "futures 0.3.7",
  "jsonrpc-core",
  "kulupu-pow",
  "kulupu-primitives",
@@ -2746,9 +2842,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libloading"
@@ -2768,13 +2864,13 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f5a4604c1a40d75651da141dfde29ad15329f537a779528803297d2220274"
+checksum = "021f703bfef6e3da78ef9828c8a244d639b8d57eedf58360922aca5ff69dfdcd"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
@@ -2799,24 +2895,24 @@ dependencies = [
  "libp2p-yamux",
  "multihash",
  "parity-multiaddr",
- "parking_lot 0.10.2",
- "pin-project",
+ "parking_lot 0.11.0",
+ "pin-project 1.0.1",
  "smallvec 1.4.2",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f13ba8c7df0768af2eb391696d562c7de88cc3a35122531aaa6a7d77754d25"
+checksum = "3960524389409633550567e8a9e0684d25a33f4f8408887ff897dd9fdfbdb771"
 dependencies = [
  "asn1_der",
  "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
@@ -2824,17 +2920,17 @@ dependencies = [
  "multihash",
  "multistream-select",
  "parity-multiaddr",
- "parking_lot 0.10.2",
- "pin-project",
+ "parking_lot 0.11.0",
+ "pin-project 1.0.1",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.8.2",
+ "sha2 0.9.2",
  "smallvec 1.4.2",
  "thiserror",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "void",
  "zeroize",
 ]
@@ -2851,37 +2947,38 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74029ae187f35f4b8ddf26b9779a68b340045d708528a103917cdca49a296db5"
+checksum = "567962c5c5f8a1282979441300e1739ba939024010757c3dbfab4d462189df77"
 dependencies = [
  "flate2",
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf319822e08dd65c8e060d2354e9f952895bbc433f5706c75ed010c152aee5e"
+checksum = "436280f5fe21a58fcaff82c2606945579241f32bc0eaf2d39321aa4624a66e7f"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "log",
 ]
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a9acb43a3e4a4e413e0c4abe0fa49308df7c6335c88534757b647199cb8a51"
+checksum = "ecc175613c5915332fd6458895407ec242ea055ae3b107a586626d5e3349350a"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "libp2p-swarm",
+ "log",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2890,15 +2987,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20fcb60edebe3173bbb708c6ac3444afdf1e3152dc2866b10c4f5497f17467"
+checksum = "d500ad89ba14de4d18bebdff61a0ce3e769f1c5c5a95026c5da90187e5fff5c9"
 dependencies = [
- "base64 0.11.0",
- "byteorder 1.3.4",
+ "base64 0.13.0",
+ "byteorder",
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures_codec",
  "hex_fmt",
  "libp2p-core",
@@ -2908,19 +3005,19 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.8.2",
+ "sha2 0.9.2",
  "smallvec 1.4.2",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56396ee63aa9164eacf40c2c5d2bda8c4133c2f57e1b0425d51d3a4e362583b1"
+checksum = "03b90b350e37f398b73d778bd94422f4e6a3afa2c1582742ce2446b8a0dba787"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2932,15 +3029,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7fa9047f8b8f544278a35c2d9d45d3b2c1785f2d86d4e1629d6edf97be3955"
+checksum = "fb78341f114bf686d5fe50b33ff1a804d88fb326c0d39ee1c22db4346b21fc27"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec 0.5.2",
  "bytes 0.5.6",
  "either",
  "fnv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
@@ -2949,25 +3046,25 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.8.2",
+ "sha2 0.9.2",
  "smallvec 1.4.2",
  "uint",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3173b5a6b2f690c29ae07798d85b9441a131ac76ddae9015ef22905b623d0c69"
+checksum = "b575514fce0a3ccbd065d6aa377bd4d5102001b05c1a22a5eee49c450254ef0f"
 dependencies = [
  "async-std",
  "data-encoding",
  "dns-parser",
  "either",
- "futures 0.3.5",
+ "futures 0.3.7",
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
@@ -2981,49 +3078,51 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a73a799cc8410b36e40b8f4c4b6babbcb9efd3727111bf517876e4acfa612d3"
+checksum = "a92b538238c80067c6417a58a07e41002b69d129355b60ec147d6337fdff0eb0"
 dependencies = [
  "bytes 0.5.6",
- "fnv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures_codec",
  "libp2p-core",
  "log",
- "parking_lot 0.10.2",
- "unsigned-varint 0.4.0",
+ "nohash-hasher",
+ "parking_lot 0.11.0",
+ "rand 0.7.3",
+ "smallvec 1.4.2",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef6c490042f549fb1025f2892dfe6083d97a77558f450c1feebe748ca9eb15a"
+checksum = "93c77142e3e5b18fefa7d267305c777c9cbe9b2232ec489979390100bebcc1e6"
 dependencies = [
  "bytes 0.5.6",
- "curve25519-dalek 2.1.0",
- "futures 0.3.5",
+ "curve25519-dalek 3.0.0",
+ "futures 0.3.7",
  "lazy_static",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.8.2",
+ "sha2 0.9.2",
  "snow",
  "static_assertions",
- "x25519-dalek 0.6.0",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad063c21dfcea4518ac9e8bd4119d33a5b26c41e674f602f41f05617a368a5c8"
+checksum = "7257135609e8877f4d286935cbe1e572b2018946881c3e7f63054577074a7ee7"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3034,49 +3133,48 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903a12e99c72dbebefea258de887982adeacc7025baa1ceb10b7fa9928f54791"
+checksum = "c88d59ba3e710a8c8e0535cb4a52e9e46534924cbbea4691f8c3aaad17b58c61"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures_codec",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
- "rw-stream-sink",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "void",
 ]
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d0db10e139d22d7af0b23ed7949449ec86262798aa0fd01595abdbcb02dc87"
+checksum = "96b3c2d5d26a9500e959a0e19743897239a6c4be78dadf99b70414301a70c006"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "log",
- "pin-project",
+ "pin-project 0.4.27",
  "rand 0.7.3",
  "salsa20",
- "sha3 0.8.2",
+ "sha3",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0c9e8a4cd69d97e9646c54313d007512f411aba8c5226cfcda16df6a6e84a3"
+checksum = "02ba1aa5727ccc118c09ba5111480873f2fe5608cb304e258fd12c173ecf27c9"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru 0.6.0",
+ "lru 0.6.1",
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.4.2",
@@ -3086,12 +3184,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193e444210132237b81b755ec7fe53f1c4bd2f53cf719729b94c0c72eb6eaa1"
+checksum = "ffa6fa33b16956b8a58afbfebe1406866011a1ab8960765bd36868952d7be6a1"
 dependencies = [
  "either",
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -3102,14 +3200,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f42ec130d7a37a7e47bf4398026b7ad9185c08ed26972e2720f8b94112796f"
+checksum = "9d0b6f4ef48d9493607fae069deecce0579320a1f3de6cb056770b151018a9a5"
 dependencies = [
  "async-std",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
- "get_if_addrs",
+ "if-addrs",
  "ipnet",
  "libp2p-core",
  "log",
@@ -3118,23 +3216,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7acb0a034f70d7db94c300eba3f65c0f6298820105624088a9609c9974d77"
+checksum = "945bed3c989a1b290b5a0d4e8fa6e44e01840efb9a5ab3f0d3d174f0e451ac0e"
 dependencies = [
  "async-std",
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "log",
 ]
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c1faac6f92c21fbe155417957863ea822fba9e9fd5eb24c0912336a100e63f"
+checksum = "66518a4455e15c283637b4d7b579aef928b75a3fc6c50a41e7e6b9fa86672ca0"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -3144,13 +3242,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d650534ebd99f48f6fa292ed5db10d30df2444943afde4407ceeddab8e513fca"
+checksum = "edc561870477523245efaaea1b6b743c70115f10c670e62bcbbe4d3153be5f0c"
 dependencies = [
  "async-tls",
  "either",
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "log",
  "quicksink",
@@ -3159,16 +3257,16 @@ dependencies = [
  "soketto",
  "url 2.1.1",
  "webpki",
- "webpki-roots 0.18.0",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781d9b9f043dcdabc40640807125368596b849fd4d96cdca2dcf052fdf6f33fd"
+checksum = "07c0c9b6ef7a168c2ae854170b0b6b77550599afe06cc3ac390eb45c5d9c7110"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p-core",
  "parking_lot 0.11.0",
  "thiserror",
@@ -3273,7 +3371,20 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3287,11 +3398,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
+checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
 dependencies = [
- "hashbrown 0.8.2",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -3305,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "lru_time_cache"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb241df5c4caeb888755363fc95f8a896618dc0d435e9e775f7930cb099beab"
+checksum = "ebac060fafad3adedd0c66a80741a92ff4bc8e94a273df2ba3770ab206f2e29a"
 
 [[package]]
 name = "mach"
@@ -3317,6 +3428,12 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -3350,9 +3467,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memmap"
@@ -3396,7 +3513,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "keccak",
  "rand_core 0.5.1",
  "zeroize",
@@ -3404,18 +3521,18 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc03ad6f8f548db7194a5ff5a6f96342ecae4e3ef67d2bf18bacc0e245cd041"
+checksum = "9a2ef6aa869726518c5d8206fa5d1337bda8a0442807611be617891c018fa781"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c214bf3d90099b52f3e4b328ae0fe34837fd0fab683ad1e10fceb4629106df48"
+checksum = "2b3569c0dbfff1b8d5f1434c642b67f5bf81c0f354a3f5f8f180b549dba3c07c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3424,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
  "autocfg 1.0.1",
@@ -3438,7 +3555,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -3523,9 +3640,9 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1 0.9.1",
- "sha2 0.9.1",
- "sha3 0.9.1",
+ "sha-1 0.9.2",
+ "sha2 0.9.2",
+ "sha3",
  "unsigned-varint 0.5.1",
 ]
 
@@ -3537,16 +3654,16 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9157e87afbc2ef0d84cc0345423d715f445edde00141c93721c162de35a05e5"
+checksum = "36a6aa6e32fbaf16795142335967214b8564a7a4661eb6dc846ef343a6e00ac1"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "log",
- "pin-project",
+ "pin-project 1.0.1",
  "smallvec 1.4.2",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -3591,22 +3708,9 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "nix"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "void",
 ]
 
 [[package]]
@@ -3654,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.0.1",
  "num-traits",
@@ -3676,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
  "libm",
@@ -3710,6 +3814,12 @@ dependencies = [
  "indexmap",
  "wasmparser 0.57.0",
 ]
+
+[[package]]
+name = "object"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
@@ -3765,6 +3875,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3778,6 +3889,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3793,6 +3905,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3823,6 +3936,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3847,6 +3961,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3862,6 +3977,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3878,6 +3994,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3891,6 +4008,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3906,6 +4024,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3921,6 +4040,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3951,6 +4071,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3965,6 +4086,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3982,6 +4104,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3998,6 +4121,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4015,6 +4139,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4027,6 +4152,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4041,6 +4167,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4056,6 +4183,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4083,19 +4211,19 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2165a93382a93de55868dcbfa11e4a8f99676a9164eee6a2b4a9479ad319c257"
+checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
 dependencies = [
  "arrayref",
  "bs58",
- "byteorder 1.3.4",
+ "byteorder",
  "data-encoding",
  "multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "url 2.1.1",
 ]
 
@@ -4105,7 +4233,7 @@ version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec 0.5.2",
  "bitvec",
  "byte-slice-cast",
  "parity-scale-codec-derive",
@@ -4137,7 +4265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e57fea504fea33f9fbb5f49f378359030e7e026a6ab849bb9e8f0787376f1bf"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "libc",
  "log",
  "mio-named-pipes",
@@ -4155,7 +4283,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "hashbrown 0.8.2",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
@@ -4188,7 +4316,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e02a625dd75084c2a7024f07c575b61b782f729d18702dabb3cdbf31911dc61"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "bytes 0.4.12",
  "httparse",
  "log",
@@ -4267,7 +4395,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -4282,7 +4410,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -4296,7 +4424,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
  "libc",
@@ -4330,10 +4458,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "crypto-mac 0.7.0",
  "rayon",
 ]
+
+[[package]]
+name = "pdqselect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "peeking_take_while"
@@ -4354,6 +4488,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,18 +4542,38 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4385,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-utils"
@@ -4397,9 +4594,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "platforms"
@@ -4421,11 +4618,11 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7215a098a80ab8ebd6349db593dc5faf741781bad0c4b7c5701fea6af548d52c"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "log",
  "wepoll-sys",
@@ -4447,15 +4644,15 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "universal-hash",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
@@ -4504,9 +4701,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -4529,7 +4726,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
  "parking_lot 0.11.0",
@@ -4594,7 +4791,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "log",
  "parity-wasm",
 ]
@@ -4604,6 +4801,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quicksink"
@@ -4692,7 +4895,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -4741,7 +4944,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -4843,25 +5046,25 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
  "autocfg 1.0.1",
- "crossbeam-deque",
+ "crossbeam-deque 0.8.0",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-deque 0.8.0",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
  "num_cpus",
 ]
@@ -4887,25 +5090,25 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
+checksum = "e17626b2f4bcf35b84bf379072a66e28cfe5c3c6ae58b38e4914bb8891dabece"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
+checksum = "0c523ccaed8ac4b0288948849a350b37d3035827413c458b6a40ddb614bb4f72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4925,9 +5128,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4941,15 +5144,15 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "region"
@@ -5022,14 +5225,14 @@ dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustc-hash"
@@ -5083,8 +5286,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.5",
- "pin-project",
+ "futures 0.3.7",
+ "pin-project 0.4.27",
  "static_assertions",
 ]
 
@@ -5105,22 +5308,11 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2324b0e8c3bb9a586a571fdb3136f70e7e2c748de00a78043f86e0cff91f91fe"
+checksum = "c7f47b10fa80f6969bbbd9c8e7cc998f082979d402a9e10579e2303a87955395"
 dependencies = [
- "byteorder 1.3.4",
- "salsa20-core",
- "stream-cipher 0.3.2",
-]
-
-[[package]]
-name = "salsa20-core"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe6cc1b9f5a5867853ade63099de70f042f7679e408d1ffe52821c9248e6e69"
-dependencies = [
- "stream-cipher 0.3.2",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -5135,8 +5327,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5158,6 +5351,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5174,15 +5368,20 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sc-chain-spec-derive",
+ "sc-consensus-babe",
+ "sc-consensus-epochs",
+ "sc-finality-grandpa",
  "sc-network",
  "sc-telemetry",
  "serde",
  "serde_json",
  "sp-chain-spec",
+ "sp-consensus-babe",
  "sp-core",
  "sp-runtime",
 ]
@@ -5190,6 +5389,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5200,27 +5400,24 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "bip39",
  "chrono",
- "derive_more",
  "fdlimit",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hex",
- "lazy_static",
  "libp2p",
  "log",
  "names",
- "nix",
  "parity-scale-codec",
- "parity-util-mem",
  "rand 0.7.3",
  "regex",
  "rpassword",
+ "sc-cli-proc-macro",
  "sc-client-api",
- "sc-informant",
  "sc-keystore",
  "sc-network",
  "sc-service",
@@ -5231,14 +5428,13 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-keyring",
+ "sp-keystore",
  "sp-panic-handler",
  "sp-runtime",
- "sp-state-machine",
  "sp-utils",
  "sp-version",
  "structopt",
- "substrate-prometheus-endpoint",
- "time",
+ "thiserror",
  "tokio 0.2.22",
  "tracing",
  "tracing-log",
@@ -5246,12 +5442,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-cli-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sc-client-api"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
  "fnv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hash-db",
  "hex-literal 0.3.1",
  "kvdb",
@@ -5269,6 +5477,7 @@ dependencies = [
  "sp-externalities",
  "sp-inherents",
  "sp-keyring",
+ "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
@@ -5283,6 +5492,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5312,6 +5522,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5320,11 +5531,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-consensus-pow"
+name = "sc-consensus-babe"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
- "futures 0.3.5",
+ "fork-tree",
+ "futures 0.3.7",
+ "futures-timer 3.0.2",
+ "log",
+ "merlin",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "pdqselect",
+ "rand 0.7.3",
+ "retain_mut",
+ "sc-client-api",
+ "sc-consensus-epochs",
+ "sc-consensus-slots",
+ "sc-consensus-uncles",
+ "sc-keystore",
+ "sc-telemetry",
+ "schnorrkel",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-consensus-vrf",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-timestamp",
+ "sp-utils",
+ "sp-version",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
+name = "sc-consensus-epochs"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "fork-tree",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sc-client-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "sc-consensus-pow"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "derive_more",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5343,8 +5613,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-consensus-slots"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "futures 0.3.7",
+ "futures-timer 3.0.2",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sc-client-api",
+ "sc-telemetry",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
+]
+
+[[package]]
+name = "sc-consensus-uncles"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "log",
+ "sc-client-api",
+ "sp-authorship",
+ "sp-consensus",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sc-executor"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5363,6 +5672,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime-interface",
  "sp-serializer",
+ "sp-tasks",
  "sp-trie",
  "sp-version",
  "sp-wasm-interface",
@@ -5372,6 +5682,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
  "log",
@@ -5388,6 +5699,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5402,6 +5714,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5419,16 +5732,17 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "pin-project",
+ "pin-project 0.4.27",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -5445,8 +5759,8 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-finality-grandpa",
- "sp-finality-tracker",
  "sp-inherents",
+ "sp-keystore",
  "sp-runtime",
  "sp-utils",
  "substrate-prometheus-endpoint",
@@ -5455,9 +5769,10 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "ansi_term 0.12.1",
- "futures 0.3.5",
+ "futures 0.3.7",
  "log",
  "parity-util-mem",
  "sc-client-api",
@@ -5472,8 +5787,12 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
+ "async-trait",
  "derive_more",
+ "futures 0.3.7",
+ "futures-util",
  "hex",
  "merlin",
  "parking_lot 0.10.2",
@@ -5481,12 +5800,14 @@ dependencies = [
  "serde_json",
  "sp-application-crypto",
  "sp-core",
+ "sp-keystore",
  "subtle 2.3.0",
 ]
 
 [[package]]
 name = "sc-light"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5505,6 +5826,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5516,7 +5838,7 @@ dependencies = [
  "erased-serde",
  "fnv",
  "fork-tree",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "futures_codec",
  "hex",
@@ -5529,7 +5851,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "pin-project",
+ "pin-project 0.4.27",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -5558,8 +5880,9 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -5572,12 +5895,13 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
- "hyper 0.13.8",
+ "hyper 0.13.9",
  "hyper-rustls",
  "log",
  "num_cpus",
@@ -5598,8 +5922,9 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "libp2p",
  "log",
  "serde_json",
@@ -5610,6 +5935,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5618,8 +5944,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -5636,6 +5963,7 @@ dependencies = [
  "sp-blockchain",
  "sp-chain-spec",
  "sp-core",
+ "sp-keystore",
  "sp-offchain",
  "sp-rpc",
  "sp-runtime",
@@ -5649,9 +5977,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
- "futures 0.3.5",
+ "futures 0.3.7",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -5672,8 +6001,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
@@ -5689,12 +6019,13 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
  "directories",
  "exit-future",
- "futures 0.1.29",
- "futures 0.3.5",
+ "futures 0.1.30",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -5704,7 +6035,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "pin-project",
+ "pin-project 0.4.27",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -5733,6 +6064,7 @@ dependencies = [
  "sp-externalities",
  "sp-inherents",
  "sp-io",
+ "sp-keystore",
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
@@ -5744,12 +6076,14 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "tempfile",
  "tracing",
+ "tracing-futures",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5763,13 +6097,14 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
  "parking_lot 0.10.2",
- "pin-project",
+ "pin-project 0.4.27",
  "rand 0.7.3",
  "serde",
  "slog",
@@ -5783,6 +6118,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "erased-serde",
  "log",
@@ -5801,9 +6137,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
- "futures 0.3.5",
+ "futures 0.3.7",
  "linked-hash-map",
  "log",
  "parity-util-mem",
@@ -5821,9 +6158,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-diagnose",
  "intervalier",
  "log",
@@ -5860,9 +6198,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec 0.5.2",
  "curve25519-dalek 2.1.0",
- "getrandom",
+ "getrandom 0.1.15",
  "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -5891,18 +6229,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
+checksum = "b12bd20b94c7cdfda8c7ba9b92ad0d9a56e3fa018c25fca83b51aa664c9b4c0d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5968,9 +6306,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -5987,9 +6325,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5998,9 +6336,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -6021,12 +6359,12 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -6046,28 +6384,15 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
-dependencies = [
- "block-buffer 0.7.3",
- "byte-tools",
- "digest 0.8.1",
- "keccak",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -6084,11 +6409,12 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
 dependencies = [
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -6099,11 +6425,10 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 
@@ -6191,9 +6516,9 @@ dependencies = [
  "rand_core 0.5.1",
  "ring",
  "rustc_version",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "subtle 2.3.0",
- "x25519-dalek 1.1.0",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -6202,7 +6527,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -6217,16 +6542,17 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.5",
+ "futures 0.3.7",
  "httparse",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
 ]
 
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
  "log",
@@ -6238,6 +6564,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6252,6 +6579,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6263,6 +6591,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6274,6 +6603,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6284,8 +6614,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-authorship"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "parity-scale-codec",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-block-builder"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6297,8 +6639,8 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "derive_more",
  "log",
  "lru 0.4.3",
  "parity-scale-codec",
@@ -6308,11 +6650,13 @@ dependencies = [
  "sp-database",
  "sp-runtime",
  "sp-state-machine",
+ "thiserror",
 ]
 
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "serde",
  "serde_json",
@@ -6321,9 +6665,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "derive_more",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -6340,12 +6684,34 @@ dependencies = [
  "sp-utils",
  "sp-version",
  "substrate-prometheus-endpoint",
+ "thiserror",
  "wasm-timer",
+]
+
+[[package]]
+name = "sp-consensus-babe"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "merlin",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus",
+ "sp-consensus-slots",
+ "sp-consensus-vrf",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-pow"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6355,16 +6721,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-slots"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "parity-scale-codec",
+ "sp-runtime",
+]
+
+[[package]]
+name = "sp-consensus-vrf"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "parity-scale-codec",
+ "schnorrkel",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-core"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "base58",
  "blake2-rfc",
- "byteorder 1.3.4",
- "derive_more",
+ "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -6390,6 +6777,7 @@ dependencies = [
  "sp-std",
  "sp-storage",
  "substrate-bip39",
+ "thiserror",
  "tiny-bip39",
  "tiny-keccak",
  "twox-hash",
@@ -6400,6 +6788,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6408,6 +6797,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6417,6 +6807,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6427,6 +6818,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6435,35 +6827,29 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
+ "sp-keystore",
  "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "sp-finality-tracker"
-version = "2.0.0"
-dependencies = [
- "parity-scale-codec",
- "sp-inherents",
  "sp-std",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "derive_more",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sp-core",
  "sp-std",
+ "thiserror",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "hash-db",
  "libsecp256k1",
  "log",
@@ -6471,6 +6857,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "sp-core",
  "sp-externalities",
+ "sp-keystore",
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
@@ -6484,6 +6871,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6492,8 +6880,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-keystore"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "futures 0.3.7",
+ "merlin",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "schnorrkel",
+ "sp-core",
+ "sp-externalities",
+]
+
+[[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6505,6 +6910,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6515,6 +6921,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6524,6 +6931,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "backtrace",
  "log",
@@ -6532,6 +6940,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "serde",
  "sp-core",
@@ -6540,6 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6561,6 +6971,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6576,6 +6987,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6587,6 +6999,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "serde",
  "serde_json",
@@ -6595,6 +7008,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6607,6 +7021,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6616,6 +7031,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "hash-db",
  "log",
@@ -6629,6 +7045,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-std",
  "sp-trie",
+ "thiserror",
  "trie-db",
  "trie-root",
 ]
@@ -6636,10 +7053,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6650,8 +7069,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-tasks"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
+dependencies = [
+ "log",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-runtime-interface",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-timestamp"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6665,6 +7098,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6677,9 +7111,10 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "derive_more",
- "futures 0.3.5",
+ "futures 0.3.7",
  "log",
  "parity-scale-codec",
  "serde",
@@ -6691,6 +7126,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6704,8 +7140,9 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-core",
  "futures-timer 3.0.2",
  "lazy_static",
@@ -6715,6 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6726,6 +7164,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6762,15 +7201,6 @@ dependencies = [
 
 [[package]]
 name = "stream-cipher"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "stream-cipher"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
@@ -6796,9 +7226,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
 dependencies = [
  "clap",
  "lazy_static",
@@ -6807,9 +7237,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -6855,6 +7285,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "platforms",
 ]
@@ -6862,9 +7293,10 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.5",
+ "futures 0.3.7",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6884,11 +7316,12 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.8",
+ "hyper 0.13.9",
  "log",
  "prometheus",
  "tokio 0.2.22",
@@ -6896,7 +7329,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.6"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#78fa1b8062218f1ee5a61c499f433a26ca1783aa"
 
 [[package]]
 name = "subtle"
@@ -6912,9 +7346,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6951,7 +7385,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -6979,18 +7413,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7074,7 +7508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "mio",
  "num_cpus",
  "tokio-codec",
@@ -7121,7 +7555,7 @@ checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 dependencies = [
  "bytes 0.4.12",
  "either",
- "futures 0.1.29",
+ "futures 0.1.30",
 ]
 
 [[package]]
@@ -7131,7 +7565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "tokio-io",
 ]
 
@@ -7141,7 +7575,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "tokio-executor 0.1.10",
 ]
 
@@ -7151,8 +7585,8 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
+ "crossbeam-utils 0.7.2",
+ "futures 0.1.30",
 ]
 
 [[package]]
@@ -7172,7 +7606,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "tokio-io",
  "tokio-threadpool",
 ]
@@ -7184,7 +7618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "log",
 ]
 
@@ -7195,7 +7629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d282d483052288b2308ba5ee795f5673b159c9bdf63c385a05609da782a5eae"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "mio",
  "mio-named-pipes",
  "tokio 0.1.22",
@@ -7207,8 +7641,8 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
+ "crossbeam-utils 0.7.2",
+ "futures 0.1.30",
  "lazy_static",
  "log",
  "mio",
@@ -7238,7 +7672,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
 ]
 
 [[package]]
@@ -7248,7 +7682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures 0.1.29",
+ "futures 0.1.30",
 ]
 
 [[package]]
@@ -7269,7 +7703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "iovec",
  "mio",
  "tokio-io",
@@ -7282,10 +7716,10 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
- "crossbeam-deque",
+ "crossbeam-deque 0.7.3",
  "crossbeam-queue",
- "crossbeam-utils",
- "futures 0.1.29",
+ "crossbeam-utils 0.7.2",
+ "futures 0.1.30",
  "lazy_static",
  "log",
  "num_cpus",
@@ -7299,8 +7733,8 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
+ "crossbeam-utils 0.7.2",
+ "futures 0.1.30",
  "slab",
  "tokio-executor 0.1.10",
 ]
@@ -7312,7 +7746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "log",
  "mio",
  "tokio-codec",
@@ -7327,7 +7761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.29",
+ "futures 0.1.30",
  "iovec",
  "libc",
  "log",
@@ -7354,9 +7788,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]
@@ -7373,7 +7807,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -7401,6 +7835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7423,9 +7867,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -7437,6 +7881,7 @@ dependencies = [
  "sharded-slab",
  "smallvec 1.4.2",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -7472,11 +7917,13 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twox-hash"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
+checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
+ "cfg-if 0.1.10",
  "rand 0.7.3",
+ "static_assertions",
 ]
 
 [[package]]
@@ -7486,12 +7933,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "uint"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "crunchy",
  "rustc-hex",
  "static_assertions",
@@ -7570,8 +8023,10 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 dependencies = [
+ "bytes 0.5.6",
  "futures-io",
  "futures-util",
+ "futures_codec",
 ]
 
 [[package]]
@@ -7655,7 +8110,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "log",
  "try-lock",
 ]
@@ -7688,7 +8143,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "wasm-bindgen-macro",
 ]
 
@@ -7713,7 +8168,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -7754,7 +8209,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "js-sys",
  "parking_lot 0.11.0",
  "pin-utils",
@@ -7806,7 +8261,7 @@ checksum = "1cd3c4f449382779ef6e0a7c3ec6752ae614e20a42e4100000c3efdc973100e2"
 dependencies = [
  "anyhow",
  "backtrace",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
  "libc",
  "log",
@@ -7848,7 +8303,7 @@ dependencies = [
  "anyhow",
  "base64 0.12.3",
  "bincode",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
@@ -7877,7 +8332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e914c013c7a9f15f4e429d5431f2830fb8adb56e40567661b69c5ec1d645be23"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
@@ -7920,7 +8375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8d4d1af8dd5f7096cfcc89dd668d358e52980c38cce199643372ffd6590e27"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 0.1.10",
  "gimli 0.21.0",
  "lazy_static",
  "libc",
@@ -7940,7 +8395,7 @@ checksum = "3a25f140bbbaadb07c531cba99ce1a966dba216138dc1b2a0ddecec851a01a93"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "indexmap",
  "lazy_static",
  "libc",
@@ -7955,18 +8410,18 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "25.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c67a4386e4efe10563552848d8c6a4b7f941e69924a935495645c3f52b32d0"
+checksum = "b3f174eed73e885ede6c8fcc3fbea8c3757afa521840676496cde56bb742ddab"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4766d466249e23279e92c52033429eb91141c5efea1c4478138fa6f6ef4efe3e"
+checksum = "26b2dccbce4d0e14875091846e110a2369267b18ddd0d6423479b88dad914d71"
 dependencies = [
  "wast",
 ]
@@ -7993,27 +8448,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
 ]
 
 [[package]]
 name = "wepoll-sys"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc2cba3fe88be1a8fcb55c727fa4cd5b0cf2d7438722792e22f26f04bc1e0"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
  "cc",
 ]
@@ -8082,17 +8528,6 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
-dependencies = [
- "curve25519-dalek 2.1.0",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
@@ -8108,7 +8543,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,15 +212,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
  "vec-arena",
 ]
 
@@ -234,14 +234,14 @@ dependencies = [
  "async-io",
  "futures-lite",
  "num_cpus",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.1.10"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
+checksum = "40a0b2bb8ae20fede194e779150fe283f65a4a08461b496de546ec366b174ad9"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -249,7 +249,7 @@ dependencies = [
  "libc",
  "log",
  "nb-connect",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
  "parking",
  "polling",
  "vec-arena",
@@ -286,7 +286,7 @@ dependencies = [
  "log",
  "memchr",
  "num_cpus",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -558,7 +558,7 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
 ]
 
 [[package]]
@@ -566,6 +566,12 @@ name = "bs58"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
@@ -637,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 dependencies = [
  "jobserver",
 ]
@@ -1346,7 +1352,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
 ]
 
 [[package]]
@@ -1418,7 +1424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8feb87a63249689640ac9c011742c33139204e3c134293d3054022276869133b"
 dependencies = [
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 2.0.2",
  "log",
  "num-traits",
@@ -1466,15 +1472,25 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1492,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1514,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1530,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1541,14 +1557,14 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "bitflags",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
  "parity-scale-codec",
  "paste",
  "serde",
@@ -1566,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1577,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1589,7 +1605,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1615,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1629,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1677,9 +1693,9 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1692,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1711,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
 name = "futures-core-preview"
@@ -1738,7 +1754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdcef58a173af8148b182684c9f2d5250875adbcaff7b5794073894f9d8634a9"
 dependencies = [
  "futures 0.1.30",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "log",
  "parking_lot 0.9.0",
@@ -1749,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1761,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-lite"
@@ -1782,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1794,17 +1810,17 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
 dependencies = [
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
 ]
 
 [[package]]
@@ -1821,9 +1837,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures 0.1.30",
  "futures-channel",
@@ -1859,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "memchr",
  "pin-project 0.4.27",
 ]
@@ -2420,7 +2436,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 2.0.2",
 ]
 
@@ -2631,7 +2647,7 @@ version = "2.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "futures 0.3.7",
+ "futures 0.3.8",
  "jsonrpc-core",
  "kulupu-pow",
  "kulupu-primitives",
@@ -2664,6 +2680,7 @@ dependencies = [
  "sp-core",
  "sp-finality-grandpa",
  "sp-inherents",
+ "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
  "sp-transaction-pool",
@@ -2870,7 +2887,7 @@ checksum = "021f703bfef6e3da78ef9828c8a244d639b8d57eedf58360922aca5ff69dfdcd"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
@@ -2908,11 +2925,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3960524389409633550567e8a9e0684d25a33f4f8408887ff897dd9fdfbdb771"
 dependencies = [
  "asn1_der",
- "bs58",
+ "bs58 0.3.1",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
@@ -2952,7 +2969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567962c5c5f8a1282979441300e1739ba939024010757c3dbfab4d462189df77"
 dependencies = [
  "flate2",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
 ]
 
@@ -2962,7 +2979,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436280f5fe21a58fcaff82c2606945579241f32bc0eaf2d39321aa4624a66e7f"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
 ]
@@ -2975,7 +2992,7 @@ checksum = "ecc175613c5915332fd6458895407ec242ea055ae3b107a586626d5e3349350a"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2995,7 +3012,7 @@ dependencies = [
  "byteorder",
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "hex_fmt",
  "libp2p-core",
@@ -3017,7 +3034,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b90b350e37f398b73d778bd94422f4e6a3afa2c1582742ce2446b8a0dba787"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3037,7 +3054,7 @@ dependencies = [
  "bytes 0.5.6",
  "either",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
@@ -3064,7 +3081,7 @@ dependencies = [
  "data-encoding",
  "dns-parser",
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
@@ -3083,7 +3100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92b538238c80067c6417a58a07e41002b69d129355b60ec147d6337fdff0eb0"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -3102,7 +3119,7 @@ checksum = "93c77142e3e5b18fefa7d267305c777c9cbe9b2232ec489979390100bebcc1e6"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek 3.0.0",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -3122,7 +3139,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7257135609e8877f4d286935cbe1e572b2018946881c3e7f63054577074a7ee7"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3138,7 +3155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c88d59ba3e710a8c8e0535cb4a52e9e46534924cbbea4691f8c3aaad17b58c61"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -3154,7 +3171,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b3c2d5d26a9500e959a0e19743897239a6c4be78dadf99b70414301a70c006"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "pin-project 0.4.27",
  "rand 0.7.3",
@@ -3170,7 +3187,7 @@ checksum = "02ba1aa5727ccc118c09ba5111480873f2fe5608cb304e258fd12c173ecf27c9"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3189,7 +3206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa6fa33b16956b8a58afbfebe1406866011a1ab8960765bd36868952d7be6a1"
 dependencies = [
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -3205,7 +3222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0b6f4ef48d9493607fae069deecce0579320a1f3de6cb056770b151018a9a5"
 dependencies = [
  "async-std",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "if-addrs",
  "ipnet",
@@ -3221,7 +3238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945bed3c989a1b290b5a0d4e8fa6e44e01840efb9a5ab3f0d3d174f0e451ac0e"
 dependencies = [
  "async-std",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
 ]
@@ -3232,7 +3249,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66518a4455e15c283637b4d7b579aef928b75a3fc6c50a41e7e6b9fa86672ca0"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -3248,14 +3265,14 @@ checksum = "edc561870477523245efaaea1b6b743c70115f10c670e62bcbbe4d3153be5f0c"
 dependencies = [
  "async-tls",
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
  "quicksink",
  "rustls",
  "rw-stream-sink",
  "soketto",
- "url 2.1.1",
+ "url 2.2.0",
  "webpki",
  "webpki-roots",
 ]
@@ -3266,7 +3283,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07c0c9b6ef7a168c2ae854170b0b6b77550599afe06cc3ac390eb45c5d9c7110"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "parking_lot 0.11.0",
  "thiserror",
@@ -3654,12 +3671,12 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a6aa6e32fbaf16795142335967214b8564a7a4661eb6dc846ef343a6e00ac1"
+checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "pin-project 1.0.1",
  "smallvec 1.4.2",
@@ -3832,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "f53cef67919d7d247eb9a2f128ca9e522789967ef1eb4ccd8c71a95a8aedf596"
 dependencies = [
  "parking_lot 0.11.0",
 ]
@@ -3875,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3889,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3905,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3936,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3961,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3977,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3994,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4008,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4024,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4040,7 +4057,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4071,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4086,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4104,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4121,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4139,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4152,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4167,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4183,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4211,12 +4228,12 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
+checksum = "22fe99b938abd57507e37f8d4ef30cd74b33c71face2809b37b8beb71bab15ab"
 dependencies = [
  "arrayref",
- "bs58",
+ "bs58 0.4.0",
  "byteorder",
  "data-encoding",
  "multihash",
@@ -4224,7 +4241,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "unsigned-varint 0.5.1",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4325,7 +4342,7 @@ dependencies = [
  "rand 0.7.3",
  "sha-1 0.8.2",
  "slab",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -5189,7 +5206,7 @@ checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
  "spin",
  "untrusted",
  "web-sys",
@@ -5286,7 +5303,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "pin-project 0.4.27",
  "static_assertions",
 ]
@@ -5327,9 +5344,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5351,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5368,7 +5385,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5389,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5400,14 +5417,14 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "bip39",
  "chrono",
  "fdlimit",
- "futures 0.3.7",
+ "futures 0.3.8",
  "hex",
  "libp2p",
  "log",
@@ -5444,7 +5461,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5455,11 +5472,11 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "hex-literal 0.3.1",
  "kvdb",
@@ -5492,7 +5509,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5522,7 +5539,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5533,11 +5550,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
  "fork-tree",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "merlin",
@@ -5578,7 +5595,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5591,10 +5608,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-pow"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5615,9 +5632,9 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5626,6 +5643,7 @@ dependencies = [
  "sc-telemetry",
  "sp-api",
  "sp-application-crypto",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
@@ -5639,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5653,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5682,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
  "log",
@@ -5699,7 +5717,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5714,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5732,12 +5750,12 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5769,10 +5787,10 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "ansi_term 0.12.1",
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "parity-util-mem",
  "sc-client-api",
@@ -5787,11 +5805,11 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-util",
  "hex",
  "merlin",
@@ -5807,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5826,19 +5844,19 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "async-std",
  "async-trait",
  "bitflags",
- "bs58",
+ "bs58 0.3.1",
  "bytes 0.5.6",
  "derive_more",
  "either",
  "erased-serde",
  "fnv",
  "fork-tree",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "futures_codec",
  "hex",
@@ -5880,9 +5898,9 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -5895,11 +5913,11 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "hyper 0.13.9",
  "hyper-rustls",
@@ -5922,9 +5940,9 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p",
  "log",
  "serde_json",
@@ -5935,7 +5953,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5944,9 +5962,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -5977,10 +5995,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6001,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -6019,13 +6037,13 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
  "directories",
  "exit-future",
  "futures 0.1.30",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -6083,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6097,9 +6115,9 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -6118,7 +6136,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "erased-serde",
  "log",
@@ -6137,10 +6155,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "linked-hash-map",
  "log",
  "parity-util-mem",
@@ -6158,10 +6176,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-diagnose",
  "intervalier",
  "log",
@@ -6523,9 +6541,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -6542,7 +6560,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.7",
+ "futures 0.3.8",
  "httparse",
  "log",
  "rand 0.7.3",
@@ -6552,7 +6570,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
  "log",
@@ -6564,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6579,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6591,7 +6609,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6603,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6616,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6627,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6639,7 +6657,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "lru 0.4.3",
@@ -6656,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6665,9 +6683,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -6691,7 +6709,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6711,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6723,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6732,7 +6750,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6744,14 +6762,14 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "base58",
  "blake2-rfc",
  "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -6788,7 +6806,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6797,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6807,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6818,7 +6836,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6835,7 +6853,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6847,9 +6865,9 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "libsecp256k1",
  "log",
@@ -6871,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6882,11 +6900,11 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6898,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6910,7 +6928,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6921,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6931,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "backtrace",
  "log",
@@ -6940,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "serde",
  "sp-core",
@@ -6949,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6971,7 +6989,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6987,7 +7005,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6999,7 +7017,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "serde",
  "serde_json",
@@ -7008,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7021,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7031,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "hash-db",
  "log",
@@ -7053,12 +7071,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7071,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "sp-core",
@@ -7084,7 +7102,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7098,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7111,10 +7129,10 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "parity-scale-codec",
  "serde",
@@ -7126,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7140,9 +7158,9 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-core",
  "futures-timer 3.0.2",
  "lazy_static",
@@ -7152,7 +7170,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7164,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7285,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "platforms",
 ]
@@ -7293,10 +7311,10 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.7",
+ "futures 0.3.8",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -7316,7 +7334,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#1aad4f1357d9780221a3b27ac967324f31bd76f9"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#71d027841a57a6bfa0549218923e78477cf96a0a"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7469,7 +7487,7 @@ checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
  "hmac",
- "once_cell 1.4.1",
+ "once_cell 1.5.1",
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
@@ -7498,9 +7516,18 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -7971,9 +7998,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
 dependencies = [
  "tinyvec",
 ]
@@ -8049,10 +8076,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -8210,7 +8238,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "js-sys",
  "parking_lot 0.11.0",
  "pin-utils",
@@ -8411,18 +8439,18 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "26.0.1"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f174eed73e885ede6c8fcc3fbea8c3757afa521840676496cde56bb742ddab"
+checksum = "c2c3ef5f6a72dffa44c24d5811123f704e18a1dbc83637d347b1852b41d3835c"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b2dccbce4d0e14875091846e110a2369267b18ddd0d6423479b88dad914d71"
+checksum = "835cf59c907f67e2bbc20f50157e08f35006fe2a8444d8ec9f5683e22f937045"
 dependencies = [
  "wast",
 ]
@@ -8544,7 +8572,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,31 +20,31 @@ serde_json = "1.0"
 jsonrpc-core = "15.0.0"
 parking_lot = "0.10.0"
 
-sc-cli = { path = "vendor/substrate/client/cli" }
-sc-rpc = { path = "vendor/substrate/client/rpc" }
-sc-keystore = { path = "vendor/substrate/client/keystore" }
-sp-core = { path = "vendor/substrate/primitives/core" }
-sp-api = { path = "vendor/substrate/primitives/api" }
-sp-blockchain = { path = "vendor/substrate/primitives/blockchain" }
-sp-block-builder = { path = "vendor/substrate/primitives/block-builder" }
-sc-rpc-api = { path = "vendor/substrate/client/rpc-api" }
-sp-timestamp = { path = "vendor/substrate/primitives/timestamp" }
-sc-executor = { path = "vendor/substrate/client/executor" }
-sc-service = { path = "vendor/substrate/client/service" }
-sp-inherents = { path = "vendor/substrate/primitives/inherents" }
-sc-transaction-pool = { path = "vendor/substrate/client/transaction-pool" }
-sp-transaction-pool = { path = "vendor/substrate/primitives/transaction-pool" }
-sc-network = { path = "vendor/substrate/client/network" }
-sc-consensus-pow = { path = "vendor/substrate/client/consensus/pow" }
-sp-consensus = { path = "vendor/substrate/primitives/consensus/common" }
-sc-consensus = { path = "vendor/substrate/client/consensus/common" }
-sc-finality-grandpa = { path = "vendor/substrate/client/finality-grandpa" }
-sp-finality-grandpa = { path = "vendor/substrate/primitives/finality-grandpa" }
-sc-client-api = { path = "vendor/substrate/client/api" }
-sp-runtime = { path = "vendor/substrate/primitives/runtime" }
-sc-basic-authorship = { path = "vendor/substrate/client/basic-authorship" }
-substrate-frame-rpc-system = { path = "vendor/substrate/utils/frame/rpc/system" }
-pallet-transaction-payment-rpc = { path = "vendor/substrate/frame/transaction-payment/rpc/" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-consensus-pow = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 
 pallet-rewards = { path = "frame/rewards" }
 pallet-eras = { path = "frame/eras" }
@@ -53,11 +53,11 @@ kulupu-runtime = { path = "runtime" }
 kulupu-primitives = { path = "primitives" }
 
 # benchmarking
-frame-benchmarking = { path = "vendor/substrate/frame/benchmarking" }
-frame-benchmarking-cli = { path = "vendor/substrate/utils/frame/benchmarking-cli" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 
 [build-dependencies]
-substrate-build-script-utils = { path = "vendor/substrate/utils/build-script-utils" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 
 [features]
 default = []
@@ -78,4 +78,3 @@ members = [
 	"frame/rewards",
 	"frame/eras",
 ]
-exclude = ["vendor"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ parking_lot = "0.10.0"
 
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ LABEL maintainer "wei@that.world"
 LABEL description="Kulupu builder."
 
 ARG PROFILE=release
-ARG STABLE=1.45.2
-ARG NIGHTLY=nightly-2020-08-29
+ARG STABLE=1.47.0
+ARG NIGHTLY=nightly-2020-10-23
 WORKDIR /rustbuilder
 COPY . /rustbuilder/kulupu
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,8 @@ trigger:
 - refs/tags/*
 
 variables:
-  RUST_STABLE: 1.45.2
-  RUST_NIGHTLY: nightly-2020-08-29
+  RUST_STABLE: 1.47.0
+  RUST_NIGHTLY: nightly-2020-10-23
 
 jobs:
 - job: Linux

--- a/frame/difficulty/Cargo.toml
+++ b/frame/difficulty/Cargo.toml
@@ -9,13 +9,14 @@ description = "Difficulty adjustment module for Kulupu."
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { path = "../../vendor/substrate/primitives/std", default-features = false }
-sp-core = { path = "../../vendor/substrate/primitives/core", default-features = false }
-sp-runtime = { path = "../../vendor/substrate/primitives/runtime", default-features = false }
-sp-timestamp = { path = "../../vendor/substrate/primitives/timestamp", default-features = false }
-frame-system = { path = "../../vendor/substrate/frame/system", default-features = false }
-frame-support = { path = "../../vendor/substrate/frame/support", default-features = false }
-pallet-timestamp = { path = "../../vendor/substrate/frame/timestamp", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+
 kulupu-primitives = { path = "../../primitives", default-features = false }
 
 [features]

--- a/frame/eras/Cargo.toml
+++ b/frame/eras/Cargo.toml
@@ -9,9 +9,9 @@ description = "Era information recording for later use."
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { path = "../../vendor/substrate/primitives/std", default-features = false }
-frame-system = { path = "../../vendor/substrate/frame/system", default-features = false }
-frame-support = { path = "../../vendor/substrate/frame/support", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/rewards/Cargo.toml
+++ b/frame/rewards/Cargo.toml
@@ -8,20 +8,20 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
-sp-runtime = { path = "../../vendor/substrate/primitives/runtime", default-features = false }
-sp-std = { path = "../../vendor/substrate/primitives/std", default-features = false }
-sp-inherents = { path = "../../vendor/substrate/primitives/inherents", default-features = false }
-sp-consensus-pow = { path = "../../vendor/substrate/primitives/consensus/pow", default-features = false }
-frame-support = { path = "../../vendor/substrate/frame/support", default-features = false }
-frame-system = { path = "../../vendor/substrate/frame/system", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-consensus-pow = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 
 # Benchmarking
-frame-benchmarking = { path = "../../vendor/substrate/frame/benchmarking", default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false, optional = true }
 
 [dev-dependencies]
-sp-core = { path = "../../vendor/substrate/primitives/core", default-features = false }
-sp-io = { path = "../../vendor/substrate/primitives/io", default-features = false }
-pallet-balances = { path = "../../vendor/substrate/frame/balances", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -39,7 +39,7 @@ use sp_consensus_pow::POW_ENGINE_ID;
 use sp_inherents::ProvideInherentData;
 use frame_support::{
 	decl_module, decl_storage, decl_error, decl_event, ensure,
-	traits::{Get, Currency, LockIdentifier, LockableCurrency, WithdrawReason},
+	traits::{Get, Currency, LockIdentifier, LockableCurrency, WithdrawReasons},
 	weights::{DispatchClass, Weight},
 };
 use frame_system::{ensure_none, ensure_root, ensure_signed};
@@ -348,7 +348,7 @@ impl<T: Trait> Module<T> {
 			REWARDS_ID,
 			&author,
 			total_locked,
-			WithdrawReason::Transfer | WithdrawReason::Reserve,
+			WithdrawReasons::except(WithdrawReasons::TRANSACTION_PAYMENT),
 		);
 
 		<Self as Store>::RewardLocks::insert(author, locks);

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -13,17 +13,17 @@ rand = { version = "0.7", features = ["small_rng"] }
 lazy_static = "1.4"
 parking_lot = "0.10.0"
 humantime = "2.0.1"
-sp-blockchain = { path = "../vendor/substrate/primitives/blockchain" }
-sp-consensus = { path = "../vendor/substrate/primitives/consensus/common" }
-sp-consensus-pow = { path = "../vendor/substrate/primitives/consensus/pow" }
-sp-runtime = { path = "../vendor/substrate/primitives/runtime" }
-sp-inherents = { path = "../vendor/substrate/primitives/inherents" }
-sp-core = { path = "../vendor/substrate/primitives/core" }
-sp-api = { path = "../vendor/substrate/primitives/api" }
-sp-application-crypto = { path = "../vendor/substrate/primitives/application-crypto" }
-sc-client-api = { package = "sc-client-api", path = "../vendor/substrate/client/api" }
-sc-consensus-pow = { path = "../vendor/substrate/client/consensus/pow" }
-sc-keystore = { path = "../vendor/substrate/client/keystore" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-consensus-pow = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-consensus-pow = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 kulupu-primitives = { path = "../primitives" }
 kulupu-runtime = { path = "../runtime" }
 kulupu-randomx = { path = "randomx" }

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -31,7 +31,7 @@ use sp_runtime::traits::{
 use sp_consensus_pow::{Seal as RawSeal, DifficultyApi};
 use sc_consensus_pow::PowAlgorithm;
 use sc_client_api::{blockchain::HeaderBackend, backend::AuxStore};
-use sc_keystore::KeyStorePtr;
+use sc_keystore::LocalKeystore;
 use kulupu_primitives::{Difficulty, AlgorithmApi};
 use rand::{SeedableRng, thread_rng, rngs::SmallRng};
 use log::*;
@@ -255,7 +255,7 @@ impl Stats {
 
 pub fn mine<B, C>(
 	client: &C,
-	keystore: &KeyStorePtr,
+	keystore: &LocalKeystore,
 	parent: &BlockId<B>,
 	pre_hash: &H256,
 	pre_digest: Option<&[u8]>,
@@ -296,7 +296,7 @@ pub fn mine<B, C>(
 		)
 	})?;
 
-	let pair = keystore.read().key_pair::<app::Pair>(
+	let pair = keystore.key_pair::<app::Pair>(
 		&author,
 	).map_err(|_| sc_consensus_pow::Error::<B>::Other(
 		"Unable to mine: fetch pair from author failed".to_string(),

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
-sp-core = { path = "../vendor/substrate/primitives/core", default-features = false }
-sp-api = { path = "../vendor/substrate/primitives/api", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,54 +8,54 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
-sp-std = { path = "../vendor/substrate/primitives/std", default-features = false }
-sp-io = { path = "../vendor/substrate/primitives/io", default-features = false }
-sp-version = { path = "../vendor/substrate/primitives/version", default-features = false }
-sp-core = { path = "../vendor/substrate/primitives/core", default-features = false }
-sp-runtime = { path = "../vendor/substrate/primitives/runtime", default-features = false }
-sp-offchain = { path = "../vendor/substrate/primitives/offchain", default-features = false }
-sp-consensus-pow = { path = "../vendor/substrate/primitives/consensus/pow", default-features = false }
-sp-session = { path = "../vendor/substrate/primitives/session", default-features = false }
-sp-api = { path = "../vendor/substrate/primitives/api", default-features = false }
-sp-block-builder = { path = "../vendor/substrate/primitives/block-builder", default-features = false }
-sp-transaction-pool = { path = "../vendor/substrate/primitives/transaction-pool", default-features = false }
-sp-inherents = { path = "../vendor/substrate/primitives/inherents", default-features = false }
-frame-support = { path = "../vendor/substrate/frame/support", default-features = false }
-frame-executive = { path = "../vendor/substrate/frame/executive", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-consensus-pow = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 kulupu-primitives = { path = "../primitives", default-features = false }
 smallvec = "1.4.0"
 
-system = { package = "frame-system", path = "../vendor/substrate/frame/system", default-features = false }
-balances = { package = "pallet-balances", path = "../vendor/substrate/frame/balances", default-features = false }
-utility = { package = "pallet-utility", path = "../vendor/substrate/frame/utility", default-features = false }
-indices = { package = "pallet-indices", path = "../vendor/substrate/frame/indices", default-features = false }
-timestamp = { package = "pallet-timestamp", path = "../vendor/substrate/frame/timestamp", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", path = "../vendor/substrate/frame/transaction-payment", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", path = "../vendor/substrate/frame/randomness-collective-flip", default-features = false }
-democracy = { package = "pallet-democracy", path = "../vendor/substrate/frame/democracy", default-features = false }
-collective = { package = "pallet-collective", path = "../vendor/substrate/frame/collective", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", path = "../vendor/substrate/frame/elections-phragmen", default-features = false }
-membership = { package = "pallet-membership", path = "../vendor/substrate/frame/membership", default-features = false }
-treasury = { package = "pallet-treasury", path = "../vendor/substrate/frame/treasury", default-features = false }
-scheduler = { package = "pallet-scheduler", path = "../vendor/substrate/frame/scheduler", default-features = false }
-identity = { package = "pallet-identity", path = "../vendor/substrate/frame/identity", default-features = false }
-proxy = { package = "pallet-proxy", path = "../vendor/substrate/frame/proxy", default-features = false }
-vesting = { package = "pallet-vesting", path = "../vendor/substrate/frame/vesting", default-features = false }
-multisig = { package = "pallet-multisig", path = "../vendor/substrate/frame/multisig", default-features = false }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+scheduler = { package = "pallet-scheduler", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+proxy = { package = "pallet-proxy", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+multisig = { package = "pallet-multisig", git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 rewards = { package = "pallet-rewards", path = "../frame/rewards", default-features = false }
 eras = { package = "pallet-eras", path = "../frame/eras", default-features = false }
 difficulty = { package = "pallet-difficulty", path = "../frame/difficulty", default-features = false }
 
-frame-system-rpc-runtime-api = { default-features = false, path = "../vendor/substrate/frame/system/rpc/runtime-api/" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, path = "../vendor/substrate/frame/transaction-payment/rpc/runtime-api/" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 
 # benchmarking
-frame-benchmarking = { default-features = false, path = "../vendor/substrate/frame/benchmarking", optional = true }
-frame-system-benchmarking = { default-features = false, path = "../vendor/substrate/frame/system/benchmarking", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false, optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false, optional = true }
 hex-literal = { version = "0.2.1", optional = true }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5", path = "../vendor/substrate/utils/wasm-builder-runner" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -55,7 +55,7 @@ frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", b
 hex-literal = { version = "0.2.1", optional = true }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "2.0.0" }
 
 [features]
 default = ["std"]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -19,7 +19,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates_or_path("2.0.0", "../vendor/substrate/utils/wasm-builder")
+		.with_wasm_builder_from_crates("2.0.1")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -314,8 +314,7 @@ parameter_types! {
 }
 
 impl transaction_payment::Trait for Runtime {
-	type Currency = balances::Module<Runtime>;
-	type OnTransactionPayment = DealWithFees;
+	type OnChargeTransaction = transaction_payment::CurrencyAdapter<Balances, DealWithFees>;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = WeightToFee;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment<Self, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier>;
@@ -529,7 +528,7 @@ impl elections_phragmen::Trait for Runtime {
 	type Currency = Balances;
 	type ChangeMembers = Council;
 	type InitializeMembers = Council;
-	type CurrencyToVote = CurrencyToVoteHandler<Self>;
+	type CurrencyToVote = frame_support::traits::U128CurrencyToVote;
 	type CandidacyBond = CandidacyBond;
 	type VotingBond = VotingBond;
 	type LoserCandidate = Treasury;
@@ -779,7 +778,7 @@ construct_runtime!(
 		// Basic stuff.
 		System: system::{Module, Call, Storage, Config, Event<T>} = 0,
 		RandomnessCollectiveFlip: randomness_collective_flip::{Module, Call, Storage} = 17,
-		Timestamp: timestamp::{Module, Call, Storage, Inherent, Config} = 1,
+		Timestamp: timestamp::{Module, Call, Storage, Inherent} = 1,
 		Indices: indices::{Module, Call, Storage, Config<T>, Event<T>} = 2,
 		Balances: balances::{Module, Call, Storage, Config<T>, Event<T>} = 3,
 		TransactionPayment: transaction_payment::{Module, Storage} = 18,

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -107,7 +107,6 @@ fn testnet_genesis(wasm_binary: &[u8], initial_difficulty: U256) -> GenesisConfi
 		elections_phragmen: Some(Default::default()),
 		eras: Some(Default::default()),
 		membership_Instance1: Some(Default::default()),
-		timestamp: Some(Default::default()),
 		vesting: Some(Default::default()),
 		rewards: Some(RewardsConfig {
 			reward: 60 * DOLLARS,
@@ -155,7 +154,6 @@ pub fn mainnet_genesis() -> GenesisConfig {
 		treasury: Some(Default::default()),
 		elections_phragmen: Some(Default::default()),
 		membership_Instance1: Some(Default::default()),
-		timestamp: Some(Default::default()),
 		vesting: None,
 		rewards: Some(RewardsConfig {
 			reward: 60 * DOLLARS,


### PR DESCRIPTION
* Switch from old submodule vendoring to use Cargo git dependencies.
* Update to Substrate master.

Currently this is not yet able to merge, pending a keystore issue still under discussions (https://github.com/paritytech/substrate/pull/7489).