### PR TITLE
Direct coin-holder initiated funding and remove UpdateFrequency

### DIFF
--- a/frame/rewards/src/benchmarking.rs
+++ b/frame/rewards/src/benchmarking.rs
@@ -56,7 +56,7 @@ benchmarks! {
 
 		Reward::<T>::put(T::Currency::minimum_balance());
 		Taxation::put(Perbill::zero());
-		Curve::<T>::put(vec![CurvePoint { start: 0.into(), reward: BalanceOf::<T>::max_value(), taxation: Perbill::max_value() }]);
+		Curve::<T>::put(vec![CurvePoint { start: 0u32.into(), reward: BalanceOf::<T>::max_value(), taxation: Perbill::max_value() }]);
 
 		// Whitelist transient storage items
 		frame_benchmarking::benchmarking::add_to_whitelist(Author::<T>::hashed_key().to_vec().into());
@@ -152,6 +152,14 @@ benchmarks! {
 	}: _(RawOrigin::Root, curve)
 	verify {
 		assert_last_event::<T>(Event::<T>::CurveSet.into());
+	}
+
+	// Constant time
+	fund {
+		let amount = BalanceOf::<T>::from(10000u32);
+	}: _(RawOrigin::Root, amount)
+	verify {
+		assert_last_event::<T>(Event::<T>::Funded(amount).into());
 	}
 }
 

--- a/frame/rewards/src/default_weights.rs
+++ b/frame/rewards/src/default_weights.rs
@@ -28,38 +28,41 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
 impl crate::WeightInfo for () {
 	fn on_initialize() -> Weight {
-		(50_081_000 as Weight)
+		(86_760_000 as Weight)
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn on_finalize() -> Weight {
-		(158_735_000 as Weight)
+		(265_656_000 as Weight)
 			.saturating_add(DbWeight::get().reads(5 as Weight))
 			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn note_author_prefs() -> Weight {
-		(6_936_000 as Weight)
+		(11_699_000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_reward() -> Weight {
-		(23_361_000 as Weight)
+		(41_890_000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_taxation() -> Weight {
-		(21_996_000 as Weight)
+		(38_872_000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn unlock() -> Weight {
-		(56_355_000 as Weight)
+		(94_964_000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_curve(l: u32, ) -> Weight {
-		(19_142_000 as Weight)
-			.saturating_add((62_000 as Weight).saturating_mul(l as Weight))
+		(34_301_000 as Weight)
+			.saturating_add((103_000 as Weight).saturating_mul(l as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn fund() -> Weight {
+		(55_119_000 as Weight)
 	}
 }

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -76,6 +76,7 @@ pub trait WeightInfo {
 	fn set_taxation() -> Weight;
 	fn unlock() -> Weight;
 	fn set_curve(_l: u32, ) -> Weight;
+	fn fund() -> Weight;
 }
 
 /// Trait for rewards.
@@ -140,6 +141,8 @@ decl_event! {
 		RewardChanged(Balance),
 		/// Block taxation has changed. [taxation]
 		TaxationChanged(Perbill),
+		/// Funded amount to donation address.
+		Funded(Balance),
 		/// A new curve has been set.
 		CurveSet,
 	}
@@ -271,6 +274,17 @@ decl_module! {
 
 			Curve::<T>::put(curve);
 			Self::deposit_event(Event::<T>::CurveSet);
+		}
+
+		/// Fund the donation address with coin-holder initiated taxation.
+		#[weight = T::WeightInfo::fund()]
+		fn fund(origin, amount: BalanceOf<T>) {
+			ensure_root(origin)?;
+
+			let treasury_id = T::DonationDestination::get();
+			drop(T::Currency::deposit_creating(&treasury_id, amount));
+
+			Self::deposit_event(RawEvent::Funded(amount));
 		}
 	}
 }

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -140,8 +140,6 @@ impl crate::GenerateRewardLocks<Test> for GenerateRewardLocks {
 
 parameter_types! {
 	pub DonationDestination: u64 = 255;
-	// Check every block for changes to the curve.
-	pub const UpdateFrequency: u64 = 1;
 }
 
 impl Trait for Test {
@@ -149,7 +147,6 @@ impl Trait for Test {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
-	type UpdateFrequency = UpdateFrequency;
 	type WeightInfo = ();
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -365,7 +365,6 @@ impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 
 parameter_types! {
 	pub DonationDestination: AccountId = Treasury::account_id();
-	pub const UpdateFrequency: BlockNumber = 7 * DAYS;
 }
 
 impl rewards::Trait for Runtime {
@@ -373,7 +372,6 @@ impl rewards::Trait for Runtime {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
-	type UpdateFrequency = UpdateFrequency;
 	type WeightInfo = weights::rewards::WeightInfo<Runtime>;
 }
 

--- a/runtime/src/weights/rewards.rs
+++ b/runtime/src/weights/rewards.rs
@@ -30,7 +30,7 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions for rewards.
 pub struct WeightInfo<T>(PhantomData<T>);
-impl<T: frame_system::Trait> rewards::WeightInfo for WeightInfo<T> {
+impl<T: system::Trait> rewards::WeightInfo for WeightInfo<T> {
 	fn on_initialize() -> Weight {
 		(86_760_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))

--- a/runtime/src/weights/rewards.rs
+++ b/runtime/src/weights/rewards.rs
@@ -19,7 +19,8 @@
 
 //! Weights for rewards
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
-//! DATE: 2020-10-29, STEPS: [50], REPEAT: 20, LOW RANGE: [], HIGH RANGE: []
+//! DATE: 2020-11-11, STEPS: [50, ], REPEAT: 20, LOW RANGE: [], HIGH RANGE: []
+//! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("dev"), DB CACHE: 128
 
 #![allow(unused_parens)]
 #![allow(unused_imports)]
@@ -27,41 +28,45 @@
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;
 
+/// Weight functions for rewards.
 pub struct WeightInfo<T>(PhantomData<T>);
-impl<T: system::Trait> rewards::WeightInfo for WeightInfo<T> {
+impl<T: frame_system::Trait> rewards::WeightInfo for WeightInfo<T> {
 	fn on_initialize() -> Weight {
-		(50_081_000 as Weight)
+		(86_760_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn on_finalize() -> Weight {
-		(158_735_000 as Weight)
+		(265_656_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn note_author_prefs() -> Weight {
-		(6_936_000 as Weight)
+		(11_699_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn set_reward() -> Weight {
-		(23_361_000 as Weight)
+		(41_890_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn set_taxation() -> Weight {
-		(21_996_000 as Weight)
+		(38_872_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn unlock() -> Weight {
-		(56_355_000 as Weight)
+		(94_964_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn set_curve(l: u32, ) -> Weight {
-		(19_142_000 as Weight)
-			.saturating_add((62_000 as Weight).saturating_mul(l as Weight))
+		(34_301_000 as Weight)
+			.saturating_add((103_000 as Weight).saturating_mul(l as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	fn fund() -> Weight {
+		(55_119_000 as Weight)
 	}
 }


### PR DESCRIPTION
* Add a simple method `fund` to provide direct coin-holder initiated funding.
* Remove `UpdateFrequency`, as I think it can be really confusing when using it. One storage access per block shouldn't matter much as we already do that for `Reward`.