### PR TITLE
Bump runtime spec version

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kulupu"),
 	impl_name: create_runtime_str!("kulupu"),
 	authoring_version: 5,
-	spec_version: 11,
+	spec_version: 12,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,


### PR DESCRIPTION
`11` is already in production, and it's not the same as the on-chain wasm binary any more.

fixes #103