### PR TITLE
pallet-variables: support changing constants without runtime upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,6 +2690,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
+ "pallet-variables",
  "pallet-vesting",
  "parity-scale-codec",
  "serde",
@@ -4105,6 +4106,18 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-variables"
+version = "2.4.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
  "sp-std",
 ]
 

--- a/frame/variables/Cargo.toml
+++ b/frame/variables/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "pallet-variables"
+version = "2.4.0"
+authors = ["Wei Tang <wei@that.world>"]
+license = "GPL-3.0-or-later"
+edition = "2018"
+description = "Variable storage to reduce the need of runtime upgrades."
+
+[dependencies]
+serde = { version = "1.0.101", optional = true }
+codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"serde",
+	"codec/std",
+	"sp-core/std",
+	"sp-std/std",
+	"frame-system/std",
+	"frame-support/std",
+]

--- a/frame/variables/src/lib.rs
+++ b/frame/variables/src/lib.rs
@@ -61,7 +61,7 @@ decl_module! {
 			Self::deposit_event(Event::U32Changed(key, value));
 		}
 
-		#[weight = 0]
+		#[weight = T::DbWeight::get().writes(1)]
 		fn set_u64(origin, key: H256, value: u64) {
 			ensure_root(origin)?;
 

--- a/frame/variables/src/lib.rs
+++ b/frame/variables/src/lib.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of Kulupu.
+//
+// Copyright (c) 2020 Wei Tang.
+//
+// Kulupu is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Kulupu is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kulupu. If not, see <http://www.gnu.org/licenses/>.
+
+//! Variable storage pallet.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_core::H256;
+use frame_support::{
+	decl_module, decl_storage, decl_event,
+};
+use frame_system::ensure_root;
+
+pub trait Config: frame_system::Config {
+	/// The overarching event type.
+	type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
+}
+
+decl_storage! {
+	trait Store for Module<T: Config> as Eras {
+		///	u32 storage values.
+		pub U32s: map hasher(opaque_blake2_256) H256 => Option<u32>;
+		/// u64 storage values.
+		pub U64s: map hasher(opaque_blake2_256) H256 => Option<u64>;
+	}
+}
+
+decl_event! {
+	pub enum Event {
+		/// U32 value changed.
+		U32Changed(H256, u32),
+		/// U64 value changed.
+		U64Changed(H256, u64),
+	}
+}
+
+decl_module! {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		fn deposit_event() = default;
+
+		#[weight = 0]
+		fn set_u32(origin, key: H256, value: u32) {
+			ensure_root(origin)?;
+
+			U32s::insert(key, value);
+			Self::deposit_event(Event::U32Changed(key, value));
+		}
+
+		#[weight = 0]
+		fn set_u64(origin, key: H256, value: u64) {
+			ensure_root(origin)?;
+
+			U64s::insert(key, value);
+			Self::deposit_event(Event::U64Changed(key, value));
+		}
+	}
+}

--- a/frame/variables/src/lib.rs
+++ b/frame/variables/src/lib.rs
@@ -53,7 +53,7 @@ decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
-		#[weight = 0]
+		#[weight = T::DbWeight::get().writes(1)]
 		fn set_u32(origin, key: H256, value: u32) {
 			ensure_root(origin)?;
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -46,6 +46,7 @@ multisig = { package = "pallet-multisig", git = "https://github.com/paritytech/s
 rewards = { package = "pallet-rewards", path = "../frame/rewards", default-features = false }
 eras = { package = "pallet-eras", path = "../frame/eras", default-features = false }
 difficulty = { package = "pallet-difficulty", path = "../frame/difficulty", default-features = false }
+variables = { package = "pallet-variables", path = "../frame/variables", default-features = false }
 
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu", default-features = false }
@@ -99,6 +100,7 @@ std = [
 	"rewards/std",
 	"eras/std",
 	"difficulty/std",
+	"variables/std",
 
 	"frame-system-rpc-runtime-api/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",


### PR DESCRIPTION
This allows things like council desired members count / runners up count to be changed without doing a runtime upgrade.