### PR TITLE
Enable Mandatory Donation Option in Rewards Pallet Configuration

### DIFF
--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -91,7 +91,7 @@ pub trait Config: frame_system::Config {
 	/// Generate reward locks.
 	type GenerateRewardLocks: GenerateRewardLocks<Self>;
 	/// Enable or Disable Mandatory Taxation
-	type MandatoryTaxation: Get<bool>;
+	type MandatoryDonation: Get<bool>;
 	/// Weights for this pallet.
 	type WeightInfo: WeightInfo;
 }
@@ -341,7 +341,7 @@ impl<T: Config> Module<T> {
 		drop(T::Currency::deposit_creating(&author, miner_total));
 		// Runtime configuration can decide whether we allow miners to define the donation amount
 		// or we simply place the entire taxed amount into treasury.
-		if T::MandatoryTaxation::get() {
+		if T::MandatoryDonation::get() {
 			drop(T::Currency::deposit_creating(&treasury_id, tax));
 		} else {
 			drop(T::Currency::deposit_creating(&treasury_id, donate));

--- a/frame/rewards/src/lib.rs
+++ b/frame/rewards/src/lib.rs
@@ -90,7 +90,7 @@ pub trait Config: frame_system::Config {
 	type DonationDestination: Get<Self::AccountId>;
 	/// Generate reward locks.
 	type GenerateRewardLocks: GenerateRewardLocks<Self>;
-	/// Enable or Disable Mandatory Taxation
+	/// Enable or Disable Mandatory Donation
 	type MandatoryDonation: Get<bool>;
 	/// Weights for this pallet.
 	type WeightInfo: WeightInfo;

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -133,7 +133,7 @@ impl crate::GenerateRewardLocks<Test> for GenerateRewardLocks {
 
 parameter_types! {
 	pub DonationDestination: u64 = 255;
-	pub MandatoryTaxation: bool = false;
+	pub MandatoryDonation: bool = false;
 }
 
 impl Config for Test {
@@ -141,7 +141,7 @@ impl Config for Test {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
-	type MandatoryTaxation = MandatoryTaxation;
+	type MandatoryDonation = MandatoryDonation;
 	type WeightInfo = ();
 }
 

--- a/frame/rewards/src/mock.rs
+++ b/frame/rewards/src/mock.rs
@@ -133,6 +133,7 @@ impl crate::GenerateRewardLocks<Test> for GenerateRewardLocks {
 
 parameter_types! {
 	pub DonationDestination: u64 = 255;
+	pub MandatoryTaxation: bool = false;
 }
 
 impl Config for Test {
@@ -140,6 +141,7 @@ impl Config for Test {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
+	type MandatoryTaxation = MandatoryTaxation;
 	type WeightInfo = ();
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -361,6 +361,7 @@ impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 
 parameter_types! {
 	pub DonationDestination: AccountId = Treasury::account_id();
+	pub MandatoryTaxation: bool = true;
 }
 
 impl rewards::Config for Runtime {
@@ -368,6 +369,7 @@ impl rewards::Config for Runtime {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
+	type MandatoryTaxation = MandatoryTaxation;
 	type WeightInfo = weights::rewards::WeightInfo<Runtime>;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -361,7 +361,7 @@ impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 
 parameter_types! {
 	pub DonationDestination: AccountId = Treasury::account_id();
-	pub MandatoryTaxation: bool = true;
+	pub MandatoryDonation: bool = true;
 }
 
 impl rewards::Config for Runtime {
@@ -369,7 +369,7 @@ impl rewards::Config for Runtime {
 	type Currency = Balances;
 	type DonationDestination = DonationDestination;
 	type GenerateRewardLocks = GenerateRewardLocks;
-	type MandatoryTaxation = MandatoryTaxation;
+	type MandatoryDonation = MandatoryDonation;
 	type WeightInfo = weights::rewards::WeightInfo<Runtime>;
 }
 


### PR DESCRIPTION
This PR allows the runtime to define whether we want to enable "mandatory donations" when giving out block rewards.

This PR also enables this feature into the Kulupu runtime.

## More Details

This PR may be more commonly known as "mandatory taxation". Now let me say that I HATE the phrase "mandatory taxation", because in terms of what the code does, it is not really a tax at all, but more of a donation. This is why this specific phrasing has been used.

Let me explain.

The way things work is like this:

Imagine the block reward is 10 KLP. There is already a defined taxation rate in the Kulupu runtime, lets assume that is 30%.

At the reward point of every block, 30% of the 10KLP will immediately be separated: 7 KLP & 3 KLP

The 7 KLP will be given to the miner, no questions asked. Then the 3 KLP will be given to Treasury ONLY IF the miner allows it! If the miner does not allow it (by putting a flag in their CLI), the 3 KLP will simply be destroyed (or never created is technically more accurate). This PR simply makes it so that the miner does not have the option to disable the creation of 3 KLP into treasury.

## FAQ

Here are some commonly asked q and a's:

> I am a miner, will this PR affect my block reward amount?

No! It will not! You will get exactly the same amount of KLP each block as you did before!

> Well, what will happen after this PR?

This PR makes it so that the treasury will guarantee get some tokens each block. Before it was up to the miner to mint these tokens into treasury, but now we make that donation mandatory.

> Will this affect the reward curve plan and expected token supply.

No! The reward curve and token supply already takes into account the taxation/donation amount. In fact, not donating would modify the curve by producing less tokens than expected.