### PR TITLE
pallet-variables: make key to be plaintext

### DIFF
--- a/frame/variables/src/lib.rs
+++ b/frame/variables/src/lib.rs
@@ -20,7 +20,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sp_core::H256;
+use sp_std::vec::Vec;
 use frame_support::{
 	decl_module, decl_storage, decl_event,
 };
@@ -34,18 +34,18 @@ pub trait Config: frame_system::Config {
 decl_storage! {
 	trait Store for Module<T: Config> as Eras {
 		///	u32 storage values.
-		pub U32s: map hasher(opaque_blake2_256) H256 => Option<u32>;
+		pub U32s: map hasher(blake2_128_concat) Vec<u8> => Option<u32>;
 		/// u64 storage values.
-		pub U64s: map hasher(opaque_blake2_256) H256 => Option<u64>;
+		pub U64s: map hasher(blake2_128_concat) Vec<u8> => Option<u64>;
 	}
 }
 
 decl_event! {
 	pub enum Event {
 		/// U32 value changed.
-		U32Changed(H256, u32),
+		U32Changed(Vec<u8>, u32),
 		/// U64 value changed.
-		U64Changed(H256, u64),
+		U64Changed(Vec<u8>, u64),
 	}
 }
 
@@ -54,18 +54,18 @@ decl_module! {
 		fn deposit_event() = default;
 
 		#[weight = 0]
-		fn set_u32(origin, key: H256, value: u32) {
+		fn set_u32(origin, key: Vec<u8>, value: u32) {
 			ensure_root(origin)?;
 
-			U32s::insert(key, value);
+			U32s::insert(key.clone(), value);
 			Self::deposit_event(Event::U32Changed(key, value));
 		}
 
 		#[weight = 0]
-		fn set_u64(origin, key: H256, value: u64) {
+		fn set_u64(origin, key: Vec<u8>, value: u64) {
 			ensure_root(origin)?;
 
-			U64s::insert(key, value);
+			U64s::insert(key.clone(), value);
 			Self::deposit_event(Event::U64Changed(key, value));
 		}
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,7 +31,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use sp_std::{collections::btree_map::BTreeMap, cmp::{min, max}, prelude::*};
 use codec::{Encode, Decode};
-use sp_core::{H256, OpaqueMetadata, u32_trait::{_1, _2, _4, _5}};
+use sp_core::{OpaqueMetadata, u32_trait::{_1, _2, _4, _5}};
 use sp_runtime::{
 	ApplyExtrinsicResult, Percent, ModuleId, generic, create_runtime_str, MultiSignature,
 	RuntimeDebug, Perquintill, transaction_validity::{TransactionValidity, TransactionSource},
@@ -518,14 +518,7 @@ parameter_types! {
 pub enum DesiredMembers { }
 impl frame_support::traits::Get<u32> for DesiredMembers {
 	fn get() -> u32 {
-		const KEY: H256 = H256([
-			0x74, 0x82, 0x71, 0x02, 0x15, 0x08, 0x27, 0xe8,
-			0x63, 0x77, 0x30, 0x79, 0x05, 0x2e, 0x87, 0xd9,
-			0x8c, 0x22, 0x11, 0xca, 0xbe, 0x82, 0x8e, 0xf5,
-			0xab, 0x07, 0x06, 0x28, 0x36, 0x48, 0x6a, 0xab,
-		]); // blake2("runtime::elections_phragmen::desired_members")
-
-		let var = variables::U32s::get(&KEY).unwrap_or(7);
+		let var = variables::U32s::get(b"runtime::elections_phragmen::desired_members".to_vec()).unwrap_or(7);
 		max(min(var, 50), 7)
 	}
 }
@@ -533,14 +526,7 @@ impl frame_support::traits::Get<u32> for DesiredMembers {
 pub enum DesiredRunnersUp { }
 impl frame_support::traits::Get<u32> for DesiredRunnersUp {
 	fn get() -> u32 {
-		const KEY: H256 = H256([
-			0x5c, 0x27, 0x9d, 0x6a, 0x32, 0x4d, 0x51, 0x4d,
-			0x8b, 0x1b, 0x9a, 0x69, 0x67, 0xfa, 0xec, 0x45,
-			0x9b, 0x21, 0x1a, 0x2e, 0x2c, 0xcf, 0x41, 0xba,
-			0xe3, 0x32, 0x59, 0xa8, 0x04, 0x5b, 0x55, 0xd0,
-		]); // blake2("runtime::elections_phragmen::desired_runners_up")
-
-		let var = variables::U32s::get(&KEY).unwrap_or(30);
+		let var = variables::U32s::get(b"runtime::elections_phragmen::desired_runners_up".to_vec()).unwrap_or(30);
 		max(min(var, 100), 7)
 	}
 }


### PR DESCRIPTION
While H256 might save a few bits and avoid the variance in the key, it is not reversible, meaning in the long run it may be an on-chain maintenance burden if people cannot figure out the meaning of each keys.