### PR TITLE
Bump for latest Substrate (debec91)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.4",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd795898c348a8ec9edc66ec9e014031c764d4c88cc26d09b492cd93eb41339"
+checksum = "c6447e2f8178843749e8c8003206def83ec124a7859475395777a28b5338647c"
 dependencies = [
  "either",
  "futures 0.3.12",
@@ -1529,7 +1542,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1546,8 +1559,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+version = "3.1.0"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1565,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1588,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1604,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1615,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1641,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1653,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1665,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1675,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1691,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1705,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2689,6 +2702,7 @@ dependencies = [
  "sc-rpc",
  "sc-rpc-api",
  "sc-service",
+ "sc-telemetry",
  "sc-transaction-pool",
  "serde",
  "serde_json",
@@ -2906,16 +2920,15 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
+checksum = "adc225a49973cf9ab10d0cdd6a4b8f0cda299df9b760824bbb623f15f8f0c95a"
 dependencies = [
  "atomic",
  "bytes 1.0.1",
  "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
- "libp2p-core-derive",
  "libp2p-deflate",
  "libp2p-dns",
  "libp2p-floodsub",
@@ -2930,6 +2943,7 @@ dependencies = [
  "libp2p-pnet",
  "libp2p-request-response",
  "libp2p-swarm",
+ "libp2p-swarm-derive",
  "libp2p-tcp",
  "libp2p-uds",
  "libp2p-wasm-ext",
@@ -2944,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad04d3cef6c1df366a6ab58c9cf8b06497699e335d83ac2174783946ff847d6"
+checksum = "8a2d56aadc2c2bf22cd7797f86e56a65b5b3994a0136b65be3106938acae7a26"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2971,19 +2985,9 @@ dependencies = [
  "sha2 0.9.3",
  "smallvec 1.6.1",
  "thiserror",
- "unsigned-varint 0.6.0",
+ "unsigned-varint 0.7.0",
  "void",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-core-derive"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bc40943156e42138d22ed3c57ff0e1a147237742715937622a99b10fbe0156"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3028,11 +3032,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12451ba9493e87c91baf2a6dffce9ddf1fbc807a0861532d7cf477954f8ebbee"
+checksum = "502dc5fcbfec4aa1c63ef3f7307ffe20e90c1a1387bf23ed0bec087f2dde58a1"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.0",
  "base64 0.13.0",
  "byteorder",
  "bytes 1.0.1",
@@ -3048,7 +3052,7 @@ dependencies = [
  "regex",
  "sha2 0.9.3",
  "smallvec 1.6.1",
- "unsigned-varint 0.6.0",
+ "unsigned-varint 0.7.0",
  "wasm-timer",
 ]
 
@@ -3070,12 +3074,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456f5de8e283d7800ca848b9b9a4e2a578b790bd8ae582b885e831353cf0e5df"
+checksum = "cf3da6c9acbcc05f93235d201d7d45ef4e8b88a45d8836f98becd8b4d443f066"
 dependencies = [
  "arrayvec 0.5.2",
- "asynchronous-codec",
+ "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "either",
  "fnv",
@@ -3089,16 +3093,16 @@ dependencies = [
  "sha2 0.9.3",
  "smallvec 1.6.1",
  "uint",
- "unsigned-varint 0.6.0",
+ "unsigned-varint 0.7.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b974db63233fc0e199f4ede7794294aae285c96f4b6010f853eac4099ef08590"
+checksum = "0e9e6374814d1b118d97ccabdfc975c8910bd16dc38a8bc058eeb08bf2080fe1"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -3117,11 +3121,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
+checksum = "350ce8b3923594aedabd5d6e3f875d058435052a29c3f32df378bc70d10be464"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.12",
  "libp2p-core",
@@ -3130,7 +3134,7 @@ dependencies = [
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint 0.6.0",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -3172,18 +3176,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e8c1ec305c9949351925cdc7196b9570f4330477f5e47fbf5bb340b57e26ed"
+checksum = "9d58defcadb646ae4b033e130b48d87410bf76394dc3335496cae99dac803e61"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.12",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
- "unsigned-varint 0.6.0",
+ "unsigned-varint 0.7.0",
  "void",
 ]
 
@@ -3203,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37637a4b33b5390322ccc068a33897d0aa541daf4fec99f6a7efbf37295346e"
+checksum = "10e5552827c33d8326502682da73a0ba4bfa40c1b55b216af3c303f32169dd89"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",
@@ -3217,7 +3221,7 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint 0.6.0",
+ "unsigned-varint 0.7.0",
  "wasm-timer",
 ]
 
@@ -3238,10 +3242,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-tcp"
-version = "0.27.0"
+name = "libp2p-swarm-derive"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
+checksum = "c564ebaa36a64839f51eaddb0243aaaa29ce64affb56129193cc3248b72af273"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a5aef80e519a6cb8e2663605142f97baaaea1a252eecbf8756184765f7471b"
 dependencies = [
  "async-io",
  "futures 0.3.12",
@@ -3300,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
+checksum = "4819358c542a86ff95f6ae691efb4b94ddaf477079b01a686f5705b79bfc232a"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
@@ -3405,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2382d8ed3918ea4ba70d98d5b74e47a168e0331965f3f17cdbc748bdebc5a3"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
 dependencies = [
  "hashbrown",
 ]
@@ -3896,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3910,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3924,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3940,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3971,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3996,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4012,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4045,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4059,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4075,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4091,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4122,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4137,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4155,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4169,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4185,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4202,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4213,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4229,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4257,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4287,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfda2e46fc5e14122649e2645645a81ee5844e0fb2e727ef560cc71a8b2d801"
+checksum = "d2c6805f98667a3828afb2ec2c396a8d610497e8d546f5447188aae47c5a79ec"
 dependencies = [
  "arrayref",
  "bs58",
@@ -4299,7 +4313,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.6.0",
+ "unsigned-varint 0.7.0",
  "url 2.2.0",
 ]
 
@@ -5403,7 +5417,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -5426,14 +5440,13 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-consensus",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
@@ -5443,7 +5456,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5464,7 +5477,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5475,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -5513,7 +5526,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5547,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5577,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5588,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5634,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5647,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-pow"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -5671,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -5697,7 +5710,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5711,7 +5724,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5740,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5756,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5771,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5789,9 +5802,10 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
+ "dyn-clone",
  "finality-grandpa",
  "fork-tree",
  "futures 0.3.12",
@@ -5827,7 +5841,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.12",
@@ -5845,7 +5859,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5865,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5884,11 +5898,11 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "async-std",
  "async-trait",
- "asynchronous-codec",
+ "asynchronous-codec 0.5.0",
  "bitflags",
  "bs58",
  "bytes 1.0.1",
@@ -5937,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -5953,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5980,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "libp2p",
@@ -5993,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6002,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -6036,7 +6050,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -6060,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -6078,7 +6092,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "directories",
  "exit-future",
@@ -6141,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6156,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "chrono",
  "futures 0.3.12",
@@ -6178,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6206,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6217,7 +6231,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -6239,7 +6253,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "futures-diagnose",
@@ -6604,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "sp-core",
@@ -6616,7 +6630,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6632,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6644,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6656,7 +6670,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6669,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6680,7 +6694,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6692,7 +6706,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "log",
@@ -6710,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6719,7 +6733,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -6745,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6765,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6777,7 +6791,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -6787,7 +6801,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6799,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6843,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -6852,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6862,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6873,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6890,7 +6904,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -6902,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -6926,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6937,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6954,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6967,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6978,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6988,7 +7002,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "backtrace",
 ]
@@ -6996,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "serde",
  "sp-core",
@@ -7005,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7026,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7043,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7055,7 +7069,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7064,7 +7078,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7077,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7087,7 +7101,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "hash-db",
  "log",
@@ -7109,12 +7123,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7127,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "sp-core",
@@ -7140,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7154,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7167,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -7183,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7197,7 +7211,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "futures 0.3.12",
  "futures-core",
@@ -7209,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7221,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7342,7 +7356,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "platforms",
 ]
@@ -7350,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.12",
@@ -7373,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=kulupu#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+source = "git+https://github.com/paritytech/substrate?branch=kulupu#debec916998233a287fb9e5a099c08d5e4a23db2"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8070,7 +8084,19 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.5.0",
+ "bytes 1.0.1",
+ "futures-io",
+ "futures-util",
+]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
+dependencies = [
+ "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures-io",
  "futures-util",
@@ -8638,9 +8664,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
+checksum = "1cc7bd8c983209ed5d527f44b01c41b7dc146fd960c61cf9e1d25399841dc271"
 dependencies = [
  "futures 0.3.12",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch 
 sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "kulupu" }

--- a/frame/lockdrop/src/lib.rs
+++ b/frame/lockdrop/src/lib.rs
@@ -182,11 +182,11 @@ decl_module! {
 				let current_number = frame_system::Module::<T>::block_number();
 				if current_number > info.end_block && info.child_root.is_some() {
 					match Self::child_kill(&identifier) {
-						child::KillOutcome::AllRemoved => {
+						child::KillChildStorageResult::AllRemoved(_) => {
 							Campaigns::<T>::remove(identifier);
 							Self::deposit_event(Event::<T>::CampaignRemoved(identifier));
 						},
-						child::KillOutcome::SomeRemaining => {
+						child::KillChildStorageResult::SomeRemaining(_) => {
 							Self::deposit_event(Event::<T>::CampaignPartiallyRemoved(identifier));
 						}
 					}
@@ -275,7 +275,7 @@ impl<T: Config> Module<T> {
 		child::root(&Self::child_info(identifier))
 	}
 
-	fn child_kill(identifier: &CampaignIdentifier) -> child::KillOutcome {
+	fn child_kill(identifier: &CampaignIdentifier) -> child::KillChildStorageResult {
 		child::kill_storage(&Self::child_info(identifier), Some(T::RemoveKeysLimit::get()))
 	}
 }

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -300,6 +300,9 @@ pub fn mine<B, C>(
 		&author,
 	).map_err(|_| sc_consensus_pow::Error::<B>::Other(
 		"Unable to mine: fetch pair from author failed".to_string(),
+	))?
+	.ok_or(sc_consensus_pow::Error::<B>::Other(
+		"Unable to mine: key not found in keystore".to_string(),
 	))?;
 
 	let maybe_seal = match version {


### PR DESCRIPTION
This updates Kulupu to compile with latest Substrate: https://github.com/paritytech/substrate/commit/debec916998233a287fb9e5a099c08d5e4a23db2