### PR TITLE
Make it optional to use the author commandline parameter

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -876,7 +876,7 @@ construct_runtime!(
 		// PoW consensus and era support.
 		Difficulty: difficulty::{Module, Call, Storage, Config} = 19,
 		Eras: eras::{Module, Call, Storage, Config<T>} = 20,
-		Rewards: rewards::{Module, Call, Inherent, Storage, Event<T>, Config<T>} = 4,
+		Rewards: rewards::{Module, Call, Storage, Event<T>, Config<T>} = 4,
 
 		// Governance.
 		Democracy: democracy::{Module, Call, Storage, Config, Event<T>} = 5,

--- a/src/command.rs
+++ b/src/command.rs
@@ -100,7 +100,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, .. } =
-					crate::service::new_partial(&config, None, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
+					crate::service::new_partial(&config, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
@@ -108,7 +108,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, .. } =
-					crate::service::new_partial(&config, None, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
+					crate::service::new_partial(&config, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
 		},
@@ -116,7 +116,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, .. } =
-					crate::service::new_partial(&config, None, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
+					crate::service::new_partial(&config, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
 		},
@@ -124,7 +124,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, .. } =
-					crate::service::new_partial(&config, None, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
+					crate::service::new_partial(&config, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
@@ -136,7 +136,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, backend, task_manager, .. } =
-					crate::service::new_partial(&config, None, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
+					crate::service::new_partial(&config, cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER), !cli.no_donate, !cli.disable_weak_subjectivity)?;
 				Ok((cmd.run(client, backend), task_manager))
 			})
 		},
@@ -244,7 +244,6 @@ pub fn run() -> sc_cli::Result<()> {
 					match config.role {
 						Role::Light => service::new_light(
 							config,
-							cli.author.as_ref().map(|s| s.as_str()),
 							cli.check_inherents_after.unwrap_or(DEFAULT_CHECK_INHERENTS_AFTER),
 							!cli.no_donate,
 							!cli.disable_weak_subjectivity,


### PR DESCRIPTION
This improves UX for mining -- one can now simply run `./kulupu --validator` and there's no need to go through the mining key importing process any more.

Note that still, for serious miners, it's recommended to use the mining key import process as you'll have more control over the key's lifecycle.