### PR TITLE
Keep expired campaign

### DIFF
--- a/frame/lockdrop/src/default_weights.rs
+++ b/frame/lockdrop/src/default_weights.rs
@@ -33,7 +33,7 @@ impl crate::WeightInfo for () {
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
-	fn remove_expired_campaign() -> Weight {
+	fn remove_expired_child_storage() -> Weight {
 		(9_500_000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 	}

--- a/frame/lockdrop/src/lib.rs
+++ b/frame/lockdrop/src/lib.rs
@@ -183,7 +183,6 @@ decl_module! {
 				if current_number > info.end_block && info.child_root.is_some() {
 					match Self::child_kill(&identifier) {
 						child::KillChildStorageResult::AllRemoved(_) => {
-							Campaigns::<T>::remove(identifier);
 							Self::deposit_event(Event::<T>::CampaignRemoved(identifier));
 						},
 						child::KillChildStorageResult::SomeRemaining(_) => {

--- a/frame/lockdrop/src/lib.rs
+++ b/frame/lockdrop/src/lib.rs
@@ -41,7 +41,7 @@ use frame_system::{ensure_root, ensure_signed};
 pub trait WeightInfo {
 	fn create_campaign() -> Weight;
 	fn conclude_campaign() -> Weight;
-	fn remove_expired_campaign() -> Weight;
+	fn remove_expired_child_storage() -> Weight;
 	fn lock() -> Weight;
 	fn unlock() -> Weight;
 }
@@ -125,8 +125,8 @@ decl_event! {
 	pub enum Event<T> where AccountId = <T as frame_system::Config>::AccountId {
 		CampaignCreated(CampaignIdentifier),
 		CampaignConcluded(CampaignIdentifier, Vec<u8>),
-		CampaignRemoved(CampaignIdentifier),
-		CampaignPartiallyRemoved(CampaignIdentifier),
+		ChildStorageRemoved(CampaignIdentifier),
+		ChildStoragePartiallyRemoved(CampaignIdentifier),
 		Locked(CampaignIdentifier, AccountId),
 		Unlocked(CampaignIdentifier, AccountId),
 	}
@@ -173,8 +173,8 @@ decl_module! {
 			});
 		}
 
-		#[weight = T::WeightInfo::remove_expired_campaign()]
-		fn remove_expired_campaign(origin, identifier: CampaignIdentifier) {
+		#[weight = T::WeightInfo::remove_expired_child_storage()]
+		fn remove_expired_child_storage(origin, identifier: CampaignIdentifier) {
 			ensure_signed(origin)?;
 
 			let info = Campaigns::<T>::get(&identifier);
@@ -183,10 +183,10 @@ decl_module! {
 				if current_number > info.end_block && info.child_root.is_some() {
 					match Self::child_kill(&identifier) {
 						child::KillChildStorageResult::AllRemoved(_) => {
-							Self::deposit_event(Event::<T>::CampaignRemoved(identifier));
+							Self::deposit_event(Event::<T>::ChildStorageRemoved(identifier));
 						},
 						child::KillChildStorageResult::SomeRemaining(_) => {
-							Self::deposit_event(Event::<T>::CampaignPartiallyRemoved(identifier));
+							Self::deposit_event(Event::<T>::ChildStoragePartiallyRemoved(identifier));
 						}
 					}
 				}

--- a/frame/lockdrop/src/tests.rs
+++ b/frame/lockdrop/src/tests.rs
@@ -120,7 +120,7 @@ fn create_campaign_lock_works() {
 		assert_noop!(Lockdrop::lock(Origin::signed(2), 5000, TEST_CAMPAIGN, 40, None), Error::<Test>::NotEnoughBalance);
 		assert_noop!(Lockdrop::lock(Origin::signed(2), 2000, TEST_CAMPAIGN, 25, None), Error::<Test>::InvalidLockEndBlock);
 		assert_storage_noop!(Lockdrop::conclude_campaign(Origin::signed(3), TEST_CAMPAIGN).unwrap());
-		assert_storage_noop!(Lockdrop::remove_expired_campaign(Origin::signed(3), TEST_CAMPAIGN).unwrap());
+		assert_storage_noop!(Lockdrop::remove_expired_child_storage(Origin::signed(3), TEST_CAMPAIGN).unwrap());
 
 		run_to_block(15);
 		assert_storage_noop!(Lockdrop::unlock(Origin::signed(1), TEST_CAMPAIGN).unwrap());
@@ -133,7 +133,7 @@ fn create_campaign_lock_works() {
 		assert_eq!(Balances::usable_balance(2), 2000);
 
 		assert_ok!(Lockdrop::conclude_campaign(Origin::signed(3), TEST_CAMPAIGN));
-		assert_ok!(Lockdrop::remove_expired_campaign(Origin::signed(3), TEST_CAMPAIGN));
+		assert_ok!(Lockdrop::remove_expired_child_storage(Origin::signed(3), TEST_CAMPAIGN));
 
 		run_to_block(23);
 		assert_storage_noop!(Lockdrop::unlock(Origin::signed(1), TEST_CAMPAIGN).unwrap());

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -118,10 +118,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kulupu"),
 	impl_name: create_runtime_str!("kulupu"),
 	authoring_version: 5,
-	spec_version: 18,
+	spec_version: 19,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 9,
+	transaction_version: 10,
 };
 
 /// The version infromation used to identify this runtime when compiled natively.

--- a/runtime/src/weights/lockdrop.rs
+++ b/runtime/src/weights/lockdrop.rs
@@ -61,7 +61,7 @@ impl<T: frame_system::Config> lockdrop::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn remove_expired_campaign() -> Weight {
+	fn remove_expired_child_storage() -> Weight {
 		(9_500_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}


### PR DESCRIPTION
This just gives slightly more flexibility. They won't cost so much storage space anyway even if it's ever unused.