### PR TITLE
Remove signed mining and reward lock

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -335,35 +335,11 @@ pub struct GenerateRewardLocks;
 
 impl rewards::GenerateRewardLocks<Runtime> for GenerateRewardLocks {
 	fn generate_reward_locks(
-		current_block: BlockNumber,
-		total_reward: Balance,
-		lock_parameters: Option<rewards::LockParameters>,
+		_current_block: BlockNumber,
+		_total_reward: Balance,
+		_lock_parameters: Option<rewards::LockParameters>,
 	) -> BTreeMap<BlockNumber, Balance> {
-		let mut locks = BTreeMap::new();
-		let locked_reward = total_reward.saturating_sub(1 * DOLLARS);
-
-		if locked_reward > 0 {
-			let total_lock_period: BlockNumber;
-			let divide: BlockNumber;
-
-			if let Some(lock_parameters) = lock_parameters {
-				total_lock_period = u32::from(lock_parameters.period) * DAYS;
-				divide = u32::from(lock_parameters.divide);
-			} else {
-				total_lock_period = 100 * DAYS;
-				divide = 10;
-			}
-			for i in 0..divide {
-				let one_locked_reward = locked_reward / divide as u128;
-
-				let estimate_block_number = current_block.saturating_add((i + 1) * (total_lock_period / divide));
-				let actual_block_number = estimate_block_number / DAYS * DAYS;
-
-				locks.insert(actual_block_number, one_locked_reward);
-			}
-		}
-
-		locks
+		Default::default()
 	}
 
 	fn max_locks(lock_bounds: rewards::LockBounds) -> u32 {
@@ -1055,7 +1031,7 @@ impl_runtime_apis! {
 
 	impl kulupu_primitives::AlgorithmApi<Block> for Runtime {
 		fn identifier() -> [u8; 8] {
-			kulupu_primitives::ALGORITHM_IDENTIFIER_V2
+			kulupu_primitives::ALGORITHM_IDENTIFIER_V1
 		}
 	}
 


### PR DESCRIPTION
Per community request, this is the PR to remove signed mining plus reward lock.

Note that this will give miners a slight advantage to only mine **after** the runtime upgrade is enacted, compared with **before**, because the reward lock before upgrade will still remain in place. 