### PR TITLE
Fix compilation debug profile on windows

### DIFF
--- a/pow/randomx/sys/build.rs
+++ b/pow/randomx/sys/build.rs
@@ -17,7 +17,11 @@ fn main() {
 	let dst = config.build();
 
 	if target.contains("pc-windows-msvc") {
-		println!("cargo:rustc-link-search=native={}/build/Release", dst.display());
+		if env::var("PROFILE").expect("PROFILE env not found") == "debug" {
+			println!("cargo:rustc-link-search=native={}/build/Debug", dst.display());
+		} else {
+			println!("cargo:rustc-link-search=native={}/build/Release", dst.display());
+		}
 	} else {
 		println!("cargo:rustc-link-search=native={}/build", dst.display());
 	}


### PR DESCRIPTION
Can`t compile with "cargo build" and "cargo test" (so without --release), on windows.