### PR TITLE
Bump dev spec version

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kulupu"),
 	impl_name: create_runtime_str!("kulupu"),
 	authoring_version: 5,
-	spec_version: 24,
+	spec_version: 25,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 10,


### PR DESCRIPTION
Avoids someone accidentally use the master branch (instead of release tags) running a mining node causing issues.